### PR TITLE
Implementing Page Allocator

### DIFF
--- a/boot/boot.s
+++ b/boot/boot.s
@@ -55,7 +55,16 @@ _start:
 
 # initialize ESP to the top of our 16 KB stack in .bss
 mov  $stack_top, %esp
+
+# Multiboot v1: EBX contains the address of the multiboot_info structure.
+# Pass it as the first argument to kernel.Main(uint32).
+pushl %ebx
+
 call go_0kernel.Main
+
+# If Main ever returns, restore the stack.
+add  $4, %esp
+
 cli
 
 .Lhang:

--- a/boot/linker.ld
+++ b/boot/linker.ld
@@ -43,4 +43,6 @@ SECTIONS
         *(.bss)
         *(.bootstrap_stack)
     }
+
+  __kernel_end = .;
 }

--- a/kernel/kernel.go
+++ b/kernel/kernel.go
@@ -2,6 +2,7 @@ package kernel
 
 import (
 	"github.com/dmarro89/go-dav-os/keyboard"
+	"github.com/dmarro89/go-dav-os/mem"
 	"github.com/dmarro89/go-dav-os/shell"
 	"github.com/dmarro89/go-dav-os/terminal"
 )
@@ -13,7 +14,7 @@ func EnableInterrupts()
 func DisableInterrupts()
 func Halt()
 
-func Main() {
+func Main(multibootInfoAddr uint32) {
 	DisableInterrupts()
 	terminal.Init()
 	terminal.Clear()
@@ -26,6 +27,10 @@ func Main() {
 	PITInit(100)
 
 	shell.SetTickProvider(GetTicks)
+
+	mem.InitMultiboot(multibootInfoAddr)
+	mem.InitPFA()
+
 	EnableInterrupts()
 	shell.Init()
 

--- a/mem/allocator.go
+++ b/mem/allocator.go
@@ -1,0 +1,224 @@
+package mem
+
+import "unsafe"
+
+const pageSize = 4096
+
+// __kernel_end is the first free physical byte after the kernel
+var __kernel_end byte
+
+var (
+	pfaReady    bool
+	totalPages  uint32
+	freePages   uint32
+	bitmapPhys  uint32 // Physical address of the bitmap
+	bitmapBytes uint32
+	scanStart   uint32 // First page index to start scanning from
+)
+
+func kernelEndPhys() uint32 {
+	return uint32(uintptr(unsafe.Pointer(&__kernel_end)))
+}
+
+func alignUp(v, a uint32) uint32 {
+	return (v + (a - 1)) & ^(a - 1)
+}
+
+func alignDown(v, a uint32) uint32 {
+	return v & ^(a - 1)
+}
+
+func u64FromHiLo(hi, lo uint32) uint64 {
+	return (uint64(hi) << 32) | uint64(lo)
+}
+
+func maxAvailableEnd() uint64 {
+	// returns the highest end address among all available (type=1) regions
+	var max uint64
+	for i := 0; i < mmapCount; i++ {
+		e := mmapEntries[i]
+		if e.typ != 1 {
+			continue
+		}
+		base := u64FromHiLo(e.baseHi, e.baseLo)
+		l := u64FromHiLo(e.lenHi, e.lenLo)
+		end := base + l
+		if end > max {
+			max = end
+		}
+	}
+	return max
+}
+
+func bitmapBytePtr(off uint32) *byte {
+	// assumes identity mapping / paging off: physical == directly addressable pointer
+	return (*byte)(unsafe.Pointer(uintptr(bitmapPhys) + uintptr(off)))
+}
+
+func bitmapGet(page uint32) bool {
+	byteIdx := page >> 3
+	bit := byte(1 << (page & 7))
+	b := *bitmapBytePtr(byteIdx)
+	return (b & bit) != 0
+}
+
+func bitmapSet(page uint32, used bool) {
+	byteIdx := page >> 3
+	bit := byte(1 << (page & 7))
+	p := bitmapBytePtr(byteIdx)
+	b := *p
+	if used {
+		*p = b | bit
+	} else {
+		*p = b &^ bit
+	}
+}
+
+func markFreeRange(startPhys, endPhys uint32) {
+	// marks pages as free inside [startPhys, endPhys)
+	if endPhys <= startPhys {
+		return
+	}
+
+	start := alignUp(startPhys, pageSize)
+	end := alignDown(endPhys, pageSize)
+
+	for addr := start; addr < end; addr += pageSize {
+		page := addr / pageSize
+		if page >= totalPages {
+			break
+		}
+		if bitmapGet(page) {
+			bitmapSet(page, false)
+			freePages++
+		}
+	}
+}
+
+func markUsedRange(startPhys, endPhys uint32) {
+	// marks pages as used inside [startPhys, endPhys)
+	if endPhys <= startPhys {
+		return
+	}
+
+	start := alignDown(startPhys, pageSize)
+	end := alignUp(endPhys, pageSize)
+
+	for addr := start; addr < end; addr += pageSize {
+		page := addr / pageSize
+		if page >= totalPages {
+			break
+		}
+		if !bitmapGet(page) {
+			bitmapSet(page, true)
+			if freePages > 0 {
+				freePages--
+			}
+		}
+	}
+}
+
+func InitPFA() bool {
+	pfaReady = false
+	freePages = 0
+
+	maxEnd := maxAvailableEnd()
+	if maxEnd == 0 {
+		return false
+	}
+
+	// manage up to the highest "available" end address
+	totalPages = uint32((maxEnd + (pageSize - 1)) / pageSize)
+	if totalPages == 0 {
+		return false
+	}
+
+	bitmapBytes = (totalPages + 7) / 8
+
+	// place bitmap right after the kernel end, aligned to 4KB
+	kend := kernelEndPhys()
+	bitmapPhys = alignUp(kend, pageSize)
+
+	// reserve full pages for the bitmap
+	bitmapPages := alignUp(bitmapBytes, pageSize) / pageSize
+	bitmapEnd := bitmapPhys + bitmapPages*pageSize
+
+	// start with everything marked as used
+	for i := uint32(0); i < bitmapBytes; i++ {
+		*bitmapBytePtr(i) = 0xFF
+	}
+
+	// free pages that belong to "available" memory regions (type=1)
+	for i := 0; i < mmapCount; i++ {
+		e := mmapEntries[i]
+		if e.typ != 1 {
+			continue
+		}
+
+		// for now, only support regions below 4GiB
+		if e.baseHi != 0 || e.lenHi != 0 {
+			continue
+		}
+
+		start := e.baseLo
+		end := e.baseLo + e.lenLo
+		markFreeRange(start, end)
+	}
+
+	// reserve low memory + kernel + bitmap pages
+	// this ensures we never allocate pages overlapping our own data structures
+	markUsedRange(0, bitmapEnd)
+
+	// prefer scanning from the end of our reserved area
+	scanStart = bitmapEnd / pageSize
+
+	pfaReady = true
+	return true
+}
+
+func PFAReady() bool { return pfaReady }
+
+func TotalPages() uint32 { return totalPages }
+func FreePages() uint32  { return freePages }
+func UsedPages() uint32  { return totalPages - freePages }
+
+func AllocPage() uint32 {
+	// returns a physical address of a 4KB page, or 0 on failure
+	if !pfaReady {
+		return 0
+	}
+
+	for page := scanStart; page < totalPages; page++ {
+		if !bitmapGet(page) {
+			bitmapSet(page, true)
+			if freePages > 0 {
+				freePages--
+			}
+			return page * pageSize
+		}
+	}
+
+	return 0
+}
+
+func FreePage(addr uint32) bool {
+	// frees a page previously returned by AllocPage
+	if !pfaReady {
+		return false
+	}
+	if (addr % pageSize) != 0 {
+		return false
+	}
+
+	page := addr / pageSize
+	if page >= totalPages {
+		return false
+	}
+	if !bitmapGet(page) {
+		return false
+	}
+
+	bitmapSet(page, false)
+	freePages++
+	return true
+}

--- a/mem/multiboot.go
+++ b/mem/multiboot.go
@@ -1,0 +1,96 @@
+package mem
+
+import "unsafe"
+
+const maxMMapEntries = 64
+
+// mmapEntry is a normalized copy of one Multiboot v1 memory map entry
+type mmapEntry struct {
+	baseLo uint32
+	baseHi uint32
+	lenLo  uint32
+	lenHi  uint32
+	typ    uint32
+}
+
+var (
+	// mmapEntries stores a compact snapshot of the memory map provided by GRUB
+	mmapEntries [maxMMapEntries]mmapEntry
+	mmapCount   int
+)
+
+// readU32 reads a 32-bit value from memory at the given address
+func readU32(addr uintptr) uint32 {
+	return *(*uint32)(unsafe.Pointer(addr))
+}
+
+// InitMultiboot initializes the memory map from the Multiboot info structure
+// Returns true if the memory map is valid, false otherwise
+func InitMultiboot(mbInfoAddr uint32) bool {
+	// reset the memory map counter
+	mmapCount = 0
+
+	flags := readU32(uintptr(mbInfoAddr) + 0)
+
+	// check if the memory map is valid
+	// Multiboot v1: bit 6 -> mmap_* valid
+	if (flags & (1 << 6)) == 0 {
+		return false
+	}
+
+	// get the length and address of the memory map
+	// offset 44: mmap_length
+	// offset 48: mmap_addr
+	mmapLen := readU32(uintptr(mbInfoAddr) + 44)
+	mmapAddr := readU32(uintptr(mbInfoAddr) + 48)
+
+	// iterate over the memory map
+	p := uintptr(mmapAddr)
+	end := p + uintptr(mmapLen)
+
+	for p < end && mmapCount < maxMMapEntries {
+		// get the size of the entry
+		// offset 0: size
+		size := readU32(p)
+		// get the base of the entry
+		// offset 4: base_lo
+		baseLo := readU32(p + 4)
+		baseHi := readU32(p + 8)
+		// get the length of the entry
+		// offset 12: len_lo
+		lenLo := readU32(p + 12)
+		// get the length of the entry
+		// offset 16: len_hi
+		lenHi := readU32(p + 16)
+		// get the type of the entry
+		// offset 20: type
+		typ := readU32(p + 20)
+
+		// store the entry in the memory map
+		mmapEntries[mmapCount] = mmapEntry{
+			baseLo: baseLo, baseHi: baseHi,
+			lenLo: lenLo, lenHi: lenHi,
+			typ: typ,
+		}
+		// increment the memory map counter
+		mmapCount++
+
+		// increment the pointer by the size of the entry and 4 bytes (padding)
+		p += uintptr(size) + 4
+	}
+
+	// return true if the memory map is valid
+	return true
+}
+
+// MMapCount returns the number of memory map entries
+func MMapCount() int { return mmapCount }
+
+// MMapEntry returns the memory map entry at the given index
+func MMapEntry(i int) (baseLo, baseHi, lenLo, lenHi, typ uint32) {
+	if i < 0 || i >= mmapCount {
+		return 0, 0, 0, 0, 0
+	}
+	e := mmapEntries[i]
+	return e.baseLo, e.baseHi, e.lenLo, e.lenHi, e.typ
+}


### PR DESCRIPTION
Adds a bitmap-based 4KB page frame allocator initialized from the Multiboot v1 memory map.
Reserves low memory + kernel + bitmap region and exposes basic shell commands (mmap, pfa, alloc, free) to inspect and validate allocations.