### PR TITLE
feat: Implement Simple Round-Robin Scheduler (Issue #18)

### DIFF
--- a/kernel/irq.go
+++ b/kernel/irq.go
@@ -1,6 +1,7 @@
 package kernel
 
 import (
+	"github.com/dmarro89/go-dav-os/kernel/scheduler"
 	"github.com/dmarro89/go-dav-os/keyboard"
 )
 
@@ -9,6 +10,7 @@ var ticks uint64
 func IRQ0Handler() {
 	ticks++
 	PICEOI(0)
+	scheduler.Schedule()
 }
 
 func IRQ1Handler() {

--- a/kernel/kernel.go
+++ b/kernel/kernel.go
@@ -2,6 +2,7 @@ package kernel
 
 import (
 	"github.com/dmarro89/go-dav-os/fs"
+	"github.com/dmarro89/go-dav-os/kernel/scheduler"
 	"github.com/dmarro89/go-dav-os/keyboard"
 	"github.com/dmarro89/go-dav-os/mem"
 	"github.com/dmarro89/go-dav-os/shell"
@@ -32,6 +33,10 @@ func Main(multibootInfoAddr uint32) {
 	mem.InitMultiboot(multibootInfoAddr)
 	mem.InitPFA()
 
+	scheduler.Init()
+	scheduler.NewTask(taskA)
+	scheduler.NewTask(taskB)
+
 	fs.Init()
 
 	EnableInterrupts()
@@ -46,5 +51,21 @@ func Main(multibootInfoAddr uint32) {
 			continue
 		}
 		shell.FeedRune(r)
+	}
+}
+
+func taskA() {
+	for {
+		terminal.Print("A")
+		for i := 0; i < 1000000; i++ {
+		}
+	}
+}
+
+func taskB() {
+	for {
+		terminal.Print("B")
+		for i := 0; i < 1000000; i++ {
+		}
 	}
 }

--- a/kernel/scheduler/scheduler.go
+++ b/kernel/scheduler/scheduler.go
@@ -1,0 +1,122 @@
+package scheduler
+
+import "unsafe"
+
+const StackSize = 4096
+const MaxTasks = 16
+
+type TaskState int
+
+const (
+	TaskRunnable TaskState = iota
+	TaskRunning
+	TaskWaiting
+)
+
+type Task struct {
+	ID    int
+	ESP   uint32
+	State TaskState
+	Stack [StackSize]byte
+}
+
+var (
+	tasks       [MaxTasks]*Task
+	taskCount   int
+	currentTask *Task
+	nextID      int = 1
+
+	// Static allocation for tasks to avoid 'newobject' heap allocation
+	taskPool [MaxTasks]Task
+)
+
+// CpuSwitch is defined in switch.s
+func CpuSwitch(oldESP *uint32, newESP uint32)
+
+func Init() {
+	taskCount = 0
+	// Init initial task (0)
+	t := &taskPool[0]
+	t.ID = 0
+	t.State = TaskRunning
+
+	tasks[0] = t
+	taskCount = 1
+	currentTask = t
+}
+
+func NewTask(entry func()) *Task {
+	if taskCount >= MaxTasks {
+		return nil
+	}
+
+	idx := taskCount
+	t := &taskPool[idx]
+	t.ID = nextID
+	nextID++
+	t.State = TaskRunnable
+
+	// Setup stack
+	// Stack grows down from t.Stack[StackSize]
+
+	sp := uintptr(unsafe.Pointer(&t.Stack[StackSize-1]))
+	sp = sp & ^uintptr(15)
+
+	// Store return addr (entry) and register placeholders
+	sp -= 4
+	*(*uintptr)(unsafe.Pointer(sp)) = *(*uintptr)(unsafe.Pointer(&entry))
+
+	sp -= 16 // 4 * 4 bytes for EBP, EBX, ESI, EDI
+
+	t.ESP = uint32(sp)
+
+	tasks[idx] = t
+	taskCount++
+	return t
+}
+
+func Schedule() {
+	if taskCount <= 1 {
+		return
+	}
+
+	oldTask := currentTask
+
+	nextIndex := -1
+	currentIndex := -1
+
+	for i := 0; i < taskCount; i++ {
+		if tasks[i] == currentTask {
+			currentIndex = i
+			break
+		}
+	}
+
+	// Round robin
+	for i := 1; i < taskCount; i++ {
+		idx := (currentIndex + i) % taskCount
+		if tasks[idx].State == TaskRunnable {
+			nextIndex = idx
+			break
+		}
+	}
+
+	if nextIndex == -1 || tasks[nextIndex] == currentTask {
+		return
+	}
+
+	newTask := tasks[nextIndex]
+
+	oldTask.State = TaskRunnable
+	newTask.State = TaskRunning
+	currentTask = newTask
+
+	CpuSwitch(&oldTask.ESP, newTask.ESP)
+}
+
+func CurrentTaskID() int {
+	if currentTask == nil {
+		return -1
+	}
+	return currentTask.ID
+}

--- a/kernel/scheduler/switch.s
+++ b/kernel/scheduler/switch.s
@@ -1,0 +1,25 @@
+/* kernel/scheduler/switch.s */
+
+.section .text
+/* Updated mangled name for github.com/dmarro89/go-dav-os/kernel/scheduler.CpuSwitch */
+.global github_0com_1dmarro89_1go_x2ddav_x2dos_1kernel_1scheduler.CpuSwitch
+.type   github_0com_1dmarro89_1go_x2ddav_x2dos_1kernel_1scheduler.CpuSwitch, @function
+
+github_0com_1dmarro89_1go_x2ddav_x2dos_1kernel_1scheduler.CpuSwitch:
+    pushl %ebp
+    pushl %ebx
+    pushl %esi
+    pushl %edi
+
+    movl 20(%esp), %eax  /* old *uint32 */
+    movl 24(%esp), %edx  /* new uint32  */
+
+    movl %esp, (%eax)
+    movl %edx, %esp
+
+    popl %edi
+    popl %esi
+    popl %ebx
+    popl %ebp
+
+    ret


### PR DESCRIPTION
Closes #18

## Summary
Implemented a basic preemptive round-robin scheduler driven by the PIT interrupt.

## Changes
- **New Package `kernel/scheduler`**:
    - `scheduler.go`: Implements `Task` struct, global task queue, and `Schedule()` logic.
    - `switch.s`: Assembly routine `CpuSwitch` for saving/restoring registers (ESP, EBP, EBX, ESI, EDI).
- **Kernel Integration**:
    - Initialized scheduler in `kernel.Main`.
    - Hooked `scheduler.Schedule()` into `IRQ0Handler` (PIT) in `irq.go`.
    - Added dummy tasks `taskA` and `taskB` to demonstrate context switching.
- **Build System**:
    - Updated `Makefile` to compile and link the new scheduler package.

## Verification
- Verified compilation using `make docker-build-only`.
- `dav-go-os.iso` is successfully generated.