### PR TITLE
docs: add MkDocs and GitHub Actions for GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,17 @@
+name: Docs
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material
+      - run: mkdocs gh-deploy --force

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,10 @@
+site_name: Go DAV OS
+theme:
+  name: material
+nav:
+  - Introduction: docs/manual/00-introduction/README.md
+  - Glossary: docs/manual/00-introduction/glossary.md
+  - Architecture: docs/manual/01-overview/architecture.md
+  - Boot & GRUB: docs/manual/02-boot/boot-and-grub.md
+  - Memory Layout: docs/manual/02-boot/linker-and-initial-memory-layout.md
+  - Privilege Transition: docs/manual/03-kernel-core/privilege-transition-gdt-tss-rsp0.md


### PR DESCRIPTION
This PR adds a basic MkDocs configuration and a GitHub Actions workflow to automatically deploy the documentation to GitHub Pages on every push to main.

Fixes #100