### PR TITLE
Add US keyboard layout and dynamic keymap selection

### DIFF
--- a/keyboard/layout.go
+++ b/keyboard/layout.go
@@ -48,6 +48,54 @@ var LayoutIT = Layout{
 	0x0E: '\b',
 }
 
+var LayoutUS = Layout{
+	0x02: '1',
+	0x03: '2',
+	0x04: '3',
+	0x05: '4',
+	0x06: '5',
+	0x07: '6',
+	0x08: '7',
+	0x09: '8',
+	0x0A: '9',
+	0x0B: '0',
+
+	0x10: 'q',
+	0x11: 'w',
+	0x12: 'e',
+	0x13: 'r',
+	0x14: 't',
+	0x15: 'y',
+	0x16: 'u',
+	0x17: 'i',
+	0x18: 'o',
+	0x19: 'p',
+
+	0x1E: 'a',
+	0x1F: 's',
+	0x20: 'd',
+	0x21: 'f',
+	0x22: 'g',
+	0x23: 'h',
+	0x24: 'j',
+	0x25: 'k',
+	0x26: 'l',
+
+	0x2C: 'z',
+	0x2D: 'x',
+	0x2E: 'c',
+	0x2F: 'v',
+	0x30: 'b',
+	0x31: 'n',
+	0x32: 'm',
+
+	0x39: ' ',
+	0x1C: '\n',
+	0x0E: '\b',
+}
+
+var currentLayout = LayoutIT
+
 func isASCIILetter(r rune) bool {
 	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
 }
@@ -95,4 +143,19 @@ func toSymbol(r rune) (rune, bool) {
 	default:
 		return 0, false
 	}
+}
+
+func SetLayout(layout string) {
+	switch layout {
+	case "us":
+		currentLayout = LayoutUS
+	case "it":
+		currentLayout = LayoutIT
+	default:
+		currentLayout = LayoutIT // Default to Italian
+	}
+}
+
+func GetLayout() Layout {
+	return currentLayout
 }


### PR DESCRIPTION
Closes https://github.com/dmarro89/go-dav-os/issues/114

This PR introduces support for a US keyboard layout in addition to the existing Italian mapping. A new `keymap` shell command is implemented to allow users to switch between layouts at runtime, improving usability for a wider range of users and simplifying keyboard testing procedures. The documentation has been updated to reflect these changes and provide clear usage instructions.