### PR TITLE
 Add minimal golangci-lint configuration and integrate in CI

### DIFF
--- a/.github/workflows/build-and-run.yml
+++ b/.github/workflows/build-and-run.yml
@@ -7,6 +7,27 @@ on:
     types: [ opened, synchronize ]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.1.6
+          args: --timeout=5m
+
   build-run:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build-and-run.yml
+++ b/.github/workflows/build-and-run.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.1.6
+          version: v2.11.4
           args: --timeout=5m
 
   build-run:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,78 @@
+version: "2"
+
+run:
+  build-tags:
+    - testing
+  timeout: 5m
+  go: "1.25"
+
+linters:
+  default: none
+  enable:
+    - govet
+    - staticcheck
+    - ineffassign
+    - unused
+    - unconvert
+    - goconst
+    - revive
+
+  settings:
+    govet:
+      disable:
+        - fieldalignment   # not useful for memory-mapped kernel structs
+        - unsafeptr        # kernel code does intentional unsafe.Pointer arithmetic
+    staticcheck:
+      checks:
+        - "all"
+        - "-SA1019"        # allow deprecated symbols (runtime stubs may trigger this)
+        - "-SA5002"        # allow intentional spin loops (OS scheduler idle/run loops)
+        - "-ST1000"        # package comments not enforced (all packages are internal)
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+    revive:
+      rules:
+        - name: unused-parameter
+        - name: var-declaration
+        - name: empty-block
+
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - goconst
+          - unconvert
+          - revive
+
+      # Stub files must keep unused params to match the real (gccgo) signatures.
+      - path: stubs\.go
+        linters:
+          - unused
+          - revive
+
+      # CpuSwitch name is dictated by the assembly symbol in asm/switch.s;
+      # renaming to CPUSwitch would break the linker.
+      - path: kernel/scheduler/
+        text: "ST1003"
+
+      # Scheduler spin loops are intentional OS halt patterns.
+      - path: kernel/scheduler/
+        text: "empty-block"
+
+    paths:
+      - build
+      - iso
+      - docs
+      - asm
+      - boot
+      - user
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -106,7 +106,6 @@ func TestWriteFailure(t *testing.T) {
 
 	// Mock pfaReady to fail
 	pfaReady = func() bool { return false }
-	
 
 	name, nameLen := makeName("new.txt")
 	data := []byte("hello")
@@ -134,7 +133,7 @@ func TestWriteSuccess(t *testing.T) {
 	// We'll mock allocPage to return an address to a local slice.
 	fakePage := make([]byte, 4096)
 	pfaReady = func() bool { return true }
-	
+
 	// WARNING: In fs.go we do runtime casting from uint64 address to memory pointers.
 	// We must return a valid memory address.
 	allocPage = func() uint64 {

--- a/kernel/scheduler/scheduler.go
+++ b/kernel/scheduler/scheduler.go
@@ -25,7 +25,7 @@ var (
 	tasks       [MaxTasks]*Task
 	taskCount   int
 	currentTask *Task
-	nextID      int = 1
+	nextID      = 1
 
 	// Static allocation for tasks to avoid 'newobject' heap allocation
 	taskPool [MaxTasks]Task


### PR DESCRIPTION
Contributes to issue - #108 

## Summary
Adds automated linting to the CI pipeline with a minimal, curated set of linters compatible with this freestanding OS project.

## What changed
- .golangci.yml — New config with 8 linters (govet, staticcheck, ineffassign, unused, unconvert, goconst, revive) and 2 formatters (gofmt, goimports), tuned for the freestanding/gccgo build
- .github/workflows/build-and-run.yml — Added a separate lint job that runs in parallel with the existing build-run job
- fs/fs_test.go — Fixed trailing whitespace flagged by gofmt
- kernel/scheduler/scheduler.go — Removed redundant type in var nextID int = 1 flagged by revive