### PR TITLE
User-mode fault handling and clean task termination

### DIFF
--- a/boot/stubs_amd64.s
+++ b/boot/stubs_amd64.s
@@ -285,6 +285,7 @@ go_0kernel.StoreIDT:
 .global go_0kernel.Int80Stub
 .type   go_0kernel.Int80Stub, @function
 go_0kernel.Int80Stub:
+	pushq $0            # dummy error code
 	PUSH_REGS
 	mov %rsp, %rbp
 	andq $-16, %rsp
@@ -293,6 +294,7 @@ go_0kernel.Int80Stub:
 	call  go_0kernel.Int80Handler
 	mov %rbp, %rsp
 	POP_REGS
+	addq $8, %rsp      # pop dummy error code
 	iretq
 .size go_0kernel.Int80Stub, . - go_0kernel.Int80Stub
 
@@ -312,6 +314,14 @@ go_0kernel.GetCS:
 	ret
 .size go_0kernel.GetCS, . - go_0kernel.GetCS
 
+# uint64 go_0kernel.GetCR2()
+.global go_0kernel.GetCR2
+.type   go_0kernel.GetCR2, @function
+go_0kernel.GetCR2:
+	mov %cr2, %rax
+	ret
+.size go_0kernel.GetCR2, . - go_0kernel.GetCR2
+
 # void go_0kernel.TriggerInt80()
 .global go_0kernel.TriggerInt80
 .type   go_0kernel.TriggerInt80, @function
@@ -324,15 +334,33 @@ go_0kernel.TriggerInt80:
 .global go_0kernel.GPFaultStub
 .type   go_0kernel.GPFaultStub, @function
 go_0kernel.GPFaultStub:
-	movb $'G', %al
-	cli
-	mov $0xb8000, %rdi
-	movb $'G', (%rdi)
-	movb $0x1f, 1(%rdi)
-1:
-	hlt
-	jmp 1b
+	PUSH_REGS
+	mov %rsp, %rbp
+	andq $-16, %rsp
+	subq $8, %rsp
+	mov %rbp, %rdi
+	call  go_0kernel.GPFaultHandler
+	mov %rbp, %rsp
+	POP_REGS
+	addq $8, %rsp      # pop error code
+	iretq
 .size go_0kernel.GPFaultStub, . - go_0kernel.GPFaultStub
+
+# void go_0kernel.PFaultStub()
+.global go_0kernel.PFaultStub
+.type   go_0kernel.PFaultStub, @function
+go_0kernel.PFaultStub:
+	PUSH_REGS
+	mov %rsp, %rbp
+	andq $-16, %rsp
+	subq $8, %rsp
+	mov %rbp, %rdi
+	call  go_0kernel.PFaultHandler
+	mov %rbp, %rsp
+	POP_REGS
+	addq $8, %rsp      # pop error code
+	iretq
+.size go_0kernel.PFaultStub, . - go_0kernel.PFaultStub
 
 # void go_0kernel.DFaultStub()
 .global go_0kernel.DFaultStub
@@ -355,6 +383,14 @@ go_0kernel.getGPFaultStubAddr:
 	leaq go_0kernel.GPFaultStub(%rip), %rax
 	ret
 .size go_0kernel.getGPFaultStubAddr, . - go_0kernel.getGPFaultStubAddr
+
+# uint64 go_0kernel.getPFaultStubAddr()
+.global go_0kernel.getPFaultStubAddr
+.type   go_0kernel.getPFaultStubAddr, @function
+go_0kernel.getPFaultStubAddr:
+	leaq go_0kernel.PFaultStub(%rip), %rax
+	ret
+.size go_0kernel.getPFaultStubAddr, . - go_0kernel.getPFaultStubAddr
 
 # uint64 go_0kernel.getDFaultStubAddr()
 .global go_0kernel.getDFaultStubAddr
@@ -416,6 +452,7 @@ go_0kernel.Halt:
 .global go_0kernel.IRQ0Stub
 .type   go_0kernel.IRQ0Stub, @function
 go_0kernel.IRQ0Stub:
+	pushq $0            # dummy error code
 	PUSH_REGS
 	mov %rsp, %rbp
 	andq $-16, %rsp
@@ -423,6 +460,7 @@ go_0kernel.IRQ0Stub:
 	call go_0kernel.IRQ0Handler
 	mov %rbp, %rsp
 	POP_REGS
+	addq $8, %rsp      # pop dummy error code
 	iretq
 .size go_0kernel.IRQ0Stub, . - go_0kernel.IRQ0Stub
 
@@ -436,6 +474,7 @@ go_0kernel.getIRQ0StubAddr:
 .global go_0kernel.IRQ1Stub
 .type   go_0kernel.IRQ1Stub, @function
 go_0kernel.IRQ1Stub:
+	pushq $0            # dummy error code
 	PUSH_REGS
 	mov %rsp, %rbp
 	andq $-16, %rsp
@@ -443,6 +482,7 @@ go_0kernel.IRQ1Stub:
 	call go_0kernel.IRQ1Handler
 	mov %rbp, %rsp
 	POP_REGS
+	addq $8, %rsp      # pop dummy error code
 	iretq
 .size go_0kernel.IRQ1Stub, . - go_0kernel.IRQ1Stub
 

--- a/kernel/idt.go
+++ b/kernel/idt.go
@@ -35,9 +35,12 @@ type TrapFrame struct {
 	RDX    uint64
 	RCX    uint64
 	RAX    uint64
+	ErrorCode uint64
 	RIP    uint64
 	CS     uint64
 	RFLAGS uint64
+	UserRSP uint64
+	UserSS  uint64
 }
 
 // 16 bytes (x86_64 IDT entry)
@@ -60,10 +63,12 @@ func StoreIDT(p *[10]byte)
 
 func getInt80StubAddr() uint64
 func getGPFaultStubAddr() uint64
+func getPFaultStubAddr() uint64
 func getDFaultStubAddr() uint64
 func Int80Stub()
 func TriggerInt80()
 func GetCS() uint16
+func GetCR2() uint64
 func getIRQ0StubAddr() uint64
 func getIRQ1StubAddr() uint64
 
@@ -91,6 +96,49 @@ func Int80Handler(tf *TrapFrame) {
 		terminal.Print("unknown syscall\n")
 		tf.RAX = ^uint64(0) // return -1
 	}
+}
+
+func GPFaultHandler(tf *TrapFrame) {
+	if tf.CS&3 == 3 {
+		terminal.Print("\n#GP in user mode\n")
+		printFaultDiagnostics("General Protection Fault", tf)
+		scheduler.Exit()
+	} else {
+		terminal.Print("\n#GP in kernel mode\n")
+		printFaultDiagnostics("General Protection Fault", tf)
+		for {
+		} // Halt
+	}
+}
+
+func PFaultHandler(tf *TrapFrame) {
+	cr2 := GetCR2()
+	if tf.CS&3 == 3 {
+		terminal.Print("\n#PF in user mode\n")
+		printFaultDiagnostics("Page Fault", tf)
+		terminal.Print("CR2: ")
+		terminal.PrintHex(cr2)
+		terminal.Print("\n")
+		scheduler.Exit()
+	} else {
+		terminal.Print("\n#PF in kernel mode\n")
+		printFaultDiagnostics("Page Fault", tf)
+		terminal.Print("CR2: ")
+		terminal.PrintHex(cr2)
+		terminal.Print("\n")
+		for {
+		} // Halt
+	}
+}
+
+func printFaultDiagnostics(name string, tf *TrapFrame) {
+	terminal.Print("Fault: ")
+	terminal.Print(name)
+	terminal.Print("\nRIP: ")
+	terminal.PrintHex(tf.RIP)
+	terminal.Print("\nError Code: ")
+	terminal.PrintHex(tf.ErrorCode)
+	terminal.Print("\n")
 }
 
 func sysWrite(fd uint64, buf uintptr, n uint64) uint64 {
@@ -143,6 +191,7 @@ func InitIDT() {
 	// Install emergency handlers first
 	setIDTEntry(0x08, getDFaultStubAddr(), kernelCodeSelector, intGateKernelFlags)  // #DF
 	setIDTEntry(0x0D, getGPFaultStubAddr(), kernelCodeSelector, intGateKernelFlags) // #GP
+	setIDTEntry(0x0E, getPFaultStubAddr(), kernelCodeSelector, intGateKernelFlags) // #PF
 
 	// Install IRQ handlers
 	setIDTEntry(0x20, getIRQ0StubAddr(), kernelCodeSelector, intGateKernelFlags) // IRQ0

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -204,3 +204,23 @@ func PrintInt(v int) {
 		PutRune(rune(buf[i]))
 	}
 }
+// PrintHex prints a 64-bit value in hexadecimal format
+func PrintHex(v uint64) {
+	Print("0x")
+	if v == 0 {
+		Print("0")
+		return
+	}
+	digits := "0123456789ABCDEF"
+	var buf [16]byte
+	i := 0
+	for v > 0 {
+		buf[i] = digits[v%16]
+		v /= 16
+		i++
+	}
+	for i > 0 {
+		i--
+		PutRune(rune(buf[i]))
+	}
+}


### PR DESCRIPTION
Implements user-mode fault handling for #GP and #PF as described in #89. \n\nChanges:\n- Updated TrapFrame to include ErrorCode, UserRSP, and UserSS.\n- Updated assembly stubs to push/pop dummy error codes for consistency.\n- Implemented GPFaultHandler and PFaultHandler in Go.\n- Added user-mode detection and task termination via scheduler.Exit().\n- Added PrintHex to terminal for diagnostics.