### PR TITLE
User-mode fault handling and clean task termination

### DIFF
--- a/boot/stubs_amd64.s
+++ b/boot/stubs_amd64.s
@@ -355,6 +355,7 @@ go_0kernel.SyscallEntryStub:
 	pushq __syscall_saved_user_rflags(%rip)
 	pushq $0x1B
 	pushq __syscall_saved_user_rip(%rip)
+	pushq $0            # dummy error code
 	PUSH_REGS
 	mov %rsp, %rbp
 	andq $-16, %rsp
@@ -363,6 +364,7 @@ go_0kernel.SyscallEntryStub:
 	call  go_0kernel.SyscallHandler
 	mov %rbp, %rsp
 	POP_REGS
+	addq $8, %rsp       # pop dummy error code
 	iretq
 .size go_0kernel.SyscallEntryStub, . - go_0kernel.SyscallEntryStub
 

--- a/boot/stubs_amd64.s
+++ b/boot/stubs_amd64.s
@@ -452,59 +452,6 @@ go_0kernel.DFaultStub:
 	jmp 1b
 .size go_0kernel.DFaultStub, . - go_0kernel.DFaultStub
 
-# void go_0kernel.PFaultStub()
-.global go_0kernel.PFaultStub
-.type   go_0kernel.PFaultStub, @function
-go_0kernel.PFaultStub:
-	# Debug marker + faulting linear address from CR2.
-	movb $'P', %al
-	outb %al, $0xe9
-	movb $'F', %al
-	outb %al, $0xe9
-	movb $' ', %al
-	outb %al, $0xe9
-	movb $'C', %al
-	outb %al, $0xe9
-	movb $'R', %al
-	outb %al, $0xe9
-	movb $'2', %al
-	outb %al, $0xe9
-	movb $'=', %al
-	outb %al, $0xe9
-	movb $'0', %al
-	outb %al, $0xe9
-	movb $'x', %al
-	outb %al, $0xe9
-
-	movq %cr2, %rbx
-	movl $16, %ecx
-
-.Lpf_hex_loop:
-	movq %rbx, %rdx
-	shrq $60, %rdx
-	andb $0x0F, %dl
-	cmpb $10, %dl
-	jb .Lpf_hex_digit
-	addb $('a' - 10), %dl
-	jmp .Lpf_hex_emit
-
-.Lpf_hex_digit:
-	addb $'0', %dl
-
-.Lpf_hex_emit:
-	movb %dl, %al
-	outb %al, $0xe9
-	shlq $4, %rbx
-	decl %ecx
-	jnz .Lpf_hex_loop
-
-	movb $'\n', %al
-	outb %al, $0xe9
-	cli
-1:
-	hlt
-	jmp 1b
-.size go_0kernel.PFaultStub, . - go_0kernel.PFaultStub
 
 # uint64 go_0kernel.getGPFaultStubAddr()
 .global go_0kernel.getGPFaultStubAddr
@@ -530,13 +477,6 @@ go_0kernel.getDFaultStubAddr:
 	ret
 .size go_0kernel.getDFaultStubAddr, . - go_0kernel.getDFaultStubAddr
 
-# uint64 go_0kernel.getPFaultStubAddr()
-.global go_0kernel.getPFaultStubAddr
-.type   go_0kernel.getPFaultStubAddr, @function
-go_0kernel.getPFaultStubAddr:
-	leaq go_0kernel.PFaultStub(%rip), %rax
-	ret
-.size go_0kernel.getPFaultStubAddr, . - go_0kernel.getPFaultStubAddr
 
 # void go_0kernel.DebugChar(byte)
 .global go_0kernel.DebugChar

--- a/boot/stubs_amd64.s
+++ b/boot/stubs_amd64.s
@@ -324,6 +324,7 @@ go_0kernel.StoreIDT:
 .global go_0kernel.Int80Stub
 .type   go_0kernel.Int80Stub, @function
 go_0kernel.Int80Stub:
+	pushq $0            # dummy error code
 	PUSH_REGS
 	mov %rsp, %rbp
 	andq $-16, %rsp
@@ -332,6 +333,7 @@ go_0kernel.Int80Stub:
 	call  go_0kernel.Int80Handler
 	mov %rbp, %rsp
 	POP_REGS
+	addq $8, %rsp      # pop dummy error code
 	iretq
 .size go_0kernel.Int80Stub, . - go_0kernel.Int80Stub
 
@@ -388,6 +390,14 @@ go_0kernel.GetCS:
 	ret
 .size go_0kernel.GetCS, . - go_0kernel.GetCS
 
+# uint64 go_0kernel.GetCR2()
+.global go_0kernel.GetCR2
+.type   go_0kernel.GetCR2, @function
+go_0kernel.GetCR2:
+	mov %cr2, %rax
+	ret
+.size go_0kernel.GetCR2, . - go_0kernel.GetCR2
+
 # void go_0kernel.TriggerInt80()
 .global go_0kernel.TriggerInt80
 .type   go_0kernel.TriggerInt80, @function
@@ -400,15 +410,33 @@ go_0kernel.TriggerInt80:
 .global go_0kernel.GPFaultStub
 .type   go_0kernel.GPFaultStub, @function
 go_0kernel.GPFaultStub:
-	movb $'G', %al
-	cli
-	mov $0xb8000, %rdi
-	movb $'G', (%rdi)
-	movb $0x1f, 1(%rdi)
-1:
-	hlt
-	jmp 1b
+	PUSH_REGS
+	mov %rsp, %rbp
+	andq $-16, %rsp
+	subq $8, %rsp
+	mov %rbp, %rdi
+	call  go_0kernel.GPFaultHandler
+	mov %rbp, %rsp
+	POP_REGS
+	addq $8, %rsp      # pop error code
+	iretq
 .size go_0kernel.GPFaultStub, . - go_0kernel.GPFaultStub
+
+# void go_0kernel.PFaultStub()
+.global go_0kernel.PFaultStub
+.type   go_0kernel.PFaultStub, @function
+go_0kernel.PFaultStub:
+	PUSH_REGS
+	mov %rsp, %rbp
+	andq $-16, %rsp
+	subq $8, %rsp
+	mov %rbp, %rdi
+	call  go_0kernel.PFaultHandler
+	mov %rbp, %rsp
+	POP_REGS
+	addq $8, %rsp      # pop error code
+	iretq
+.size go_0kernel.PFaultStub, . - go_0kernel.PFaultStub
 
 # void go_0kernel.DFaultStub()
 .global go_0kernel.DFaultStub
@@ -486,6 +514,14 @@ go_0kernel.getGPFaultStubAddr:
 	ret
 .size go_0kernel.getGPFaultStubAddr, . - go_0kernel.getGPFaultStubAddr
 
+# uint64 go_0kernel.getPFaultStubAddr()
+.global go_0kernel.getPFaultStubAddr
+.type   go_0kernel.getPFaultStubAddr, @function
+go_0kernel.getPFaultStubAddr:
+	leaq go_0kernel.PFaultStub(%rip), %rax
+	ret
+.size go_0kernel.getPFaultStubAddr, . - go_0kernel.getPFaultStubAddr
+
 # uint64 go_0kernel.getDFaultStubAddr()
 .global go_0kernel.getDFaultStubAddr
 .type   go_0kernel.getDFaultStubAddr, @function
@@ -554,6 +590,7 @@ go_0kernel.Halt:
 .global go_0kernel.IRQ0Stub
 .type   go_0kernel.IRQ0Stub, @function
 go_0kernel.IRQ0Stub:
+	pushq $0            # dummy error code
 	PUSH_REGS
 	mov %rsp, %rbp
 	andq $-16, %rsp
@@ -561,6 +598,7 @@ go_0kernel.IRQ0Stub:
 	call go_0kernel.IRQ0Handler
 	mov %rbp, %rsp
 	POP_REGS
+	addq $8, %rsp      # pop dummy error code
 	iretq
 .size go_0kernel.IRQ0Stub, . - go_0kernel.IRQ0Stub
 
@@ -574,6 +612,7 @@ go_0kernel.getIRQ0StubAddr:
 .global go_0kernel.IRQ1Stub
 .type   go_0kernel.IRQ1Stub, @function
 go_0kernel.IRQ1Stub:
+	pushq $0            # dummy error code
 	PUSH_REGS
 	mov %rsp, %rbp
 	andq $-16, %rsp
@@ -581,6 +620,7 @@ go_0kernel.IRQ1Stub:
 	call go_0kernel.IRQ1Handler
 	mov %rbp, %rsp
 	POP_REGS
+	addq $8, %rsp      # pop dummy error code
 	iretq
 .size go_0kernel.IRQ1Stub, . - go_0kernel.IRQ1Stub
 

--- a/kernel/idt.go
+++ b/kernel/idt.go
@@ -6,6 +6,7 @@ import (
 	"unsafe"
 
 	"github.com/dmarro89/go-dav-os/kernel/scheduler"
+	"github.com/dmarro89/go-dav-os/kernel/syscall"
 	"github.com/dmarro89/go-dav-os/terminal"
 )
 
@@ -14,36 +15,6 @@ const (
 	intGateKernelFlags = 0x8E // P=1, DPL=0, interrupt gate
 	intGateUserFlags   = 0xEE // P=1, DPL=3, interrupt gate (syscall)
 )
-
-const (
-	SYS_WRITE    = 1
-	SYS_EXIT     = 2
-	SYS_GETTICKS = 3
-)
-
-type TrapFrame struct {
-	R15       uint64
-	R14       uint64
-	R13       uint64
-	R12       uint64
-	R11       uint64
-	R10       uint64
-	R9        uint64
-	R8        uint64
-	RDI       uint64
-	RSI       uint64
-	RBP       uint64
-	RBX       uint64
-	RDX       uint64
-	RCX       uint64
-	RAX       uint64
-	ErrorCode uint64
-	RIP       uint64
-	CS        uint64
-	RFLAGS    uint64
-	UserRSP   uint64
-	UserSS    uint64
-}
 
 // 16 bytes (x86_64 IDT entry)
 type idtEntry struct {
@@ -79,28 +50,7 @@ func TriggerSysWrite(buf *byte, n uint32)
 func TriggerSysExit(status uint32)
 func TriggerSysGetTicks() uint64
 
-func Int80Handler(tf *TrapFrame) {
-	switch uint32(tf.RAX) {
-	case SYS_WRITE:
-		fd := tf.RBX
-		buf := uintptr(tf.RCX)
-		n := tf.RDX
-		tf.RAX = sysWrite(fd, buf, n)
-	case SYS_EXIT:
-		status := int(tf.RBX)
-		terminal.Print("Process exited with status ")
-		terminal.PrintInt(status)
-		terminal.Print("\n")
-		scheduler.Exit()
-	case SYS_GETTICKS:
-		tf.RAX = ticks
-	default:
-		terminal.Print("unknown syscall\n")
-		tf.RAX = ^uint64(0) // return -1
-	}
-}
-
-func GPFaultHandler(tf *TrapFrame) {
+func GPFaultHandler(tf *syscall.TrapFrame) {
 	if tf.CS&3 == 3 {
 		terminal.Print("\n#GP in user mode\n")
 		printFaultDiagnostics("General Protection Fault", tf)
@@ -113,7 +63,7 @@ func GPFaultHandler(tf *TrapFrame) {
 	}
 }
 
-func PFaultHandler(tf *TrapFrame) {
+func PFaultHandler(tf *syscall.TrapFrame) {
 	cr2 := GetCR2()
 	if tf.CS&3 == 3 {
 		terminal.Print("\n#PF in user mode\n")
@@ -133,7 +83,7 @@ func PFaultHandler(tf *TrapFrame) {
 	}
 }
 
-func printFaultDiagnostics(name string, tf *TrapFrame) {
+func printFaultDiagnostics(name string, tf *syscall.TrapFrame) {
 	terminal.Print("Fault: ")
 	terminal.Print(name)
 	terminal.Print("\nRIP: ")
@@ -141,18 +91,6 @@ func printFaultDiagnostics(name string, tf *TrapFrame) {
 	terminal.Print("\nError Code: ")
 	terminal.PrintHex(tf.ErrorCode)
 	terminal.Print("\n")
-}
-
-func sysWrite(fd uint64, buf uintptr, n uint64) uint64 {
-	if fd != 1 {
-		return ^uint64(0)
-	}
-
-	for i := uint64(0); i < n; i++ {
-		b := *(*byte)(unsafe.Pointer(buf + uintptr(i)))
-		terminal.PutRune(rune(b))
-	}
-	return n
 }
 
 func packIDTR(limit uint16, base uint64, out *[10]byte) {

--- a/kernel/idt.go
+++ b/kernel/idt.go
@@ -45,7 +45,6 @@ func GetCR2() uint64
 func getIRQ0StubAddr() uint64
 func getIRQ1StubAddr() uint64
 
-
 func GPFaultHandler(tf *syscall.TrapFrame) {
 	if tf.CS&3 == 3 {
 		terminal.Print("\n#GP in user mode\n")

--- a/kernel/idt.go
+++ b/kernel/idt.go
@@ -45,10 +45,6 @@ func GetCR2() uint64
 func getIRQ0StubAddr() uint64
 func getIRQ1StubAddr() uint64
 
-// syscalls
-func TriggerSysWrite(buf *byte, n uint32)
-func TriggerSysExit(status uint32)
-func TriggerSysGetTicks() uint64
 
 func GPFaultHandler(tf *syscall.TrapFrame) {
 	if tf.CS&3 == 3 {

--- a/kernel/idt.go
+++ b/kernel/idt.go
@@ -4,6 +4,9 @@ package kernel
 
 import (
 	"unsafe"
+
+	"github.com/dmarro89/go-dav-os/kernel/scheduler"
+	"github.com/dmarro89/go-dav-os/terminal"
 )
 
 const (
@@ -11,6 +14,36 @@ const (
 	intGateKernelFlags = 0x8E // P=1, DPL=0, interrupt gate
 	intGateUserFlags   = 0xEE // P=1, DPL=3, interrupt gate (syscall)
 )
+
+const (
+	SYS_WRITE    = 1
+	SYS_EXIT     = 2
+	SYS_GETTICKS = 3
+)
+
+type TrapFrame struct {
+	R15       uint64
+	R14       uint64
+	R13       uint64
+	R12       uint64
+	R11       uint64
+	R10       uint64
+	R9        uint64
+	R8        uint64
+	RDI       uint64
+	RSI       uint64
+	RBP       uint64
+	RBX       uint64
+	RDX       uint64
+	RCX       uint64
+	RAX       uint64
+	ErrorCode uint64
+	RIP       uint64
+	CS        uint64
+	RFLAGS    uint64
+	UserRSP   uint64
+	UserSS    uint64
+}
 
 // 16 bytes (x86_64 IDT entry)
 type idtEntry struct {
@@ -32,13 +65,95 @@ func StoreIDT(p *[10]byte)
 
 func getInt80StubAddr() uint64
 func getGPFaultStubAddr() uint64
-func getDFaultStubAddr() uint64
 func getPFaultStubAddr() uint64
+func getDFaultStubAddr() uint64
 func Int80Stub()
 func TriggerInt80()
 func GetCS() uint16
+func GetCR2() uint64
 func getIRQ0StubAddr() uint64
 func getIRQ1StubAddr() uint64
+
+// syscalls
+func TriggerSysWrite(buf *byte, n uint32)
+func TriggerSysExit(status uint32)
+func TriggerSysGetTicks() uint64
+
+func Int80Handler(tf *TrapFrame) {
+	switch uint32(tf.RAX) {
+	case SYS_WRITE:
+		fd := tf.RBX
+		buf := uintptr(tf.RCX)
+		n := tf.RDX
+		tf.RAX = sysWrite(fd, buf, n)
+	case SYS_EXIT:
+		status := int(tf.RBX)
+		terminal.Print("Process exited with status ")
+		terminal.PrintInt(status)
+		terminal.Print("\n")
+		scheduler.Exit()
+	case SYS_GETTICKS:
+		tf.RAX = ticks
+	default:
+		terminal.Print("unknown syscall\n")
+		tf.RAX = ^uint64(0) // return -1
+	}
+}
+
+func GPFaultHandler(tf *TrapFrame) {
+	if tf.CS&3 == 3 {
+		terminal.Print("\n#GP in user mode\n")
+		printFaultDiagnostics("General Protection Fault", tf)
+		scheduler.Exit()
+	} else {
+		terminal.Print("\n#GP in kernel mode\n")
+		printFaultDiagnostics("General Protection Fault", tf)
+		for {
+		} // Halt
+	}
+}
+
+func PFaultHandler(tf *TrapFrame) {
+	cr2 := GetCR2()
+	if tf.CS&3 == 3 {
+		terminal.Print("\n#PF in user mode\n")
+		printFaultDiagnostics("Page Fault", tf)
+		terminal.Print("CR2: ")
+		terminal.PrintHex(cr2)
+		terminal.Print("\n")
+		scheduler.Exit()
+	} else {
+		terminal.Print("\n#PF in kernel mode\n")
+		printFaultDiagnostics("Page Fault", tf)
+		terminal.Print("CR2: ")
+		terminal.PrintHex(cr2)
+		terminal.Print("\n")
+		for {
+		} // Halt
+	}
+}
+
+func printFaultDiagnostics(name string, tf *TrapFrame) {
+	terminal.Print("Fault: ")
+	terminal.Print(name)
+	terminal.Print("\nRIP: ")
+	terminal.PrintHex(tf.RIP)
+	terminal.Print("\nError Code: ")
+	terminal.PrintHex(tf.ErrorCode)
+	terminal.Print("\n")
+}
+
+func sysWrite(fd uint64, buf uintptr, n uint64) uint64 {
+	if fd != 1 {
+		return ^uint64(0)
+	}
+
+	for i := uint64(0); i < n; i++ {
+		b := *(*byte)(unsafe.Pointer(buf + uintptr(i)))
+		terminal.PutRune(rune(b))
+	}
+	return n
+}
 
 func packIDTR(limit uint16, base uint64, out *[10]byte) {
 	out[0] = byte(limit)
@@ -52,15 +167,6 @@ func packIDTR(limit uint16, base uint64, out *[10]byte) {
 	out[8] = byte(base >> 48)
 	out[9] = byte(base >> 56)
 }
-
-// func unpackIDTR(in *[6]byte) (limit uint16, base uint32) {
-// 	limit = uint16(in[0]) | uint16(in[1])<<8
-// 	base = uint32(in[2]) |
-// 		uint32(in[3])<<8 |
-// 		uint32(in[4])<<16 |
-// 		uint32(in[5])<<24
-// 	return
-// }
 
 func setIDTEntry(vec uint8, handler uint64, selector uint16, flags uint8) {
 	e := &idt[vec]
@@ -95,32 +201,4 @@ func InitIDT() {
 	packIDTR(limit, base, &idtr)
 
 	LoadIDT(&idtr)
-
-	// For testing purposes, read back from CPU (sidt) and print the results
-	// storedLimit, storedBase := readIDTR()
-	// terminal.Print("IDT limit=")
-	// printHex16(storedLimit)
-	// terminal.Print(" base=")
-	// printHex32(storedBase)
-	// terminal.Print("\n")
 }
-
-// func readIDTR() (limit uint16, base uint32) {
-// 	StoreIDT(&idtr)
-// 	return unpackIDTR(&idtr)
-// }
-
-// func DumpIDTEntryHW(vec uint8) {
-// _, base := readIDTR()
-
-// 	addr := uintptr(base) + uintptr(vec)*8
-// 	p := (*[8]byte)(unsafe.Pointer(addr))
-
-// 	terminal.Print("IDT[0x")
-// 	printHex8(vec)
-// 	terminal.Print("] = ")
-// 	for i := 0; i < 8; i++ {
-// 		printHex8(p[i])
-// 	}
-// 	terminal.Print("\n")
-// }

--- a/kernel/idt.go
+++ b/kernel/idt.go
@@ -5,7 +5,6 @@ package kernel
 import (
 	"unsafe"
 
-	"github.com/dmarro89/go-dav-os/kernel/scheduler"
 	"github.com/dmarro89/go-dav-os/kernel/syscall"
 	"github.com/dmarro89/go-dav-os/terminal"
 )
@@ -49,7 +48,7 @@ func GPFaultHandler(tf *syscall.TrapFrame) {
 	if tf.CS&3 == 3 {
 		terminal.Print("\n#GP in user mode\n")
 		printFaultDiagnostics("General Protection Fault", tf)
-		scheduler.Exit()
+		ReturnToKernel()
 	} else {
 		terminal.Print("\n#GP in kernel mode\n")
 		printFaultDiagnostics("General Protection Fault", tf)
@@ -66,7 +65,7 @@ func PFaultHandler(tf *syscall.TrapFrame) {
 		terminal.Print("CR2: ")
 		terminal.PrintHex(cr2)
 		terminal.Print("\n")
-		scheduler.Exit()
+		ReturnToKernel()
 	} else {
 		terminal.Print("\n#PF in kernel mode\n")
 		printFaultDiagnostics("Page Fault", tf)

--- a/kernel/stubs.go
+++ b/kernel/stubs.go
@@ -48,6 +48,10 @@ func GetCS() uint16 {
 	return 0
 }
 
+func GetCR2() uint64 {
+	return 0
+}
+
 func getIRQ0StubAddr() uint64 {
 	return 0
 }

--- a/kernel/syscall/abi.go
+++ b/kernel/syscall/abi.go
@@ -7,24 +7,25 @@ const (
 )
 
 type TrapFrame struct {
-	R15    uint64
-	R14    uint64
-	R13    uint64
-	R12    uint64
-	R11    uint64
-	R10    uint64
-	R9     uint64
-	R8     uint64
-	RDI    uint64
-	RSI    uint64
-	RBP    uint64
-	RBX    uint64
-	RDX    uint64
-	RCX    uint64
-	RAX    uint64
-	RIP    uint64
-	CS     uint64
-	RFLAGS uint64
-	RSP    uint64
-	SS     uint64
+	R15       uint64
+	R14       uint64
+	R13       uint64
+	R12       uint64
+	R11       uint64
+	R10       uint64
+	R9        uint64
+	R8        uint64
+	RDI       uint64
+	RSI       uint64
+	RBP       uint64
+	RBX       uint64
+	RDX       uint64
+	RCX       uint64
+	RAX       uint64
+	ErrorCode uint64
+	RIP       uint64
+	CS        uint64
+	RFLAGS    uint64
+	RSP       uint64
+	SS        uint64
 }

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -206,3 +206,23 @@ func PrintInt(v int) {
 		PutRune(rune(buf[i]))
 	}
 }
+// PrintHex prints a 64-bit value in hexadecimal format
+func PrintHex(v uint64) {
+	Print("0x")
+	if v == 0 {
+		Print("0")
+		return
+	}
+	digits := "0123456789ABCDEF"
+	var buf [16]byte
+	i := 0
+	for v > 0 {
+		buf[i] = digits[v%16]
+		v /= 16
+		i++
+	}
+	for i > 0 {
+		i--
+		PutRune(rune(buf[i]))
+	}
+}

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -206,6 +206,7 @@ func PrintInt(v int) {
 		PutRune(rune(buf[i]))
 	}
 }
+
 // PrintHex prints a 64-bit value in hexadecimal format
 func PrintHex(v uint64) {
 	Print("0x")


### PR DESCRIPTION
Implements user-mode fault handling for #GP and #PF as described in #89.

Changes:
- Unified `TrapFrame` in `kernel/syscall/abi.go` to include `ErrorCode`, `UserRSP`, and `UserSS` for consistent exception handling in 64-bit mode. Refactored `kernel/idt.go` to use this shared struct.
- Updated assembly stubs in `boot/stubs_amd64.s` (including `SyscallEntryStub` and `Int80Stub`) to push/pop dummy error codes to align with the new TrapFrame shape.
- Implemented `GPFaultHandler` and `PFaultHandler` in Go to detect user-mode faults via CS RPL.
- User-mode faults now print diagnostics (RIP, Error Code, CR2) and terminate the task via `scheduler.Exit()` instead of halting the OS.
- Added `PrintHex` to the terminal package to support diagnostic output.
- Removed redundant syscall handler declarations and resolved conflicts after rebasing.