### PR TITLE
docs: Document common build and QEMU troubleshooting steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ qemu-system-x86_64 -cdrom build/dav-go-os.iso
 
 To force cross binaries: `make CROSS=x86_64-elf`
 
+## Troubleshooting
+
+If you run into issues while building or running the project, check these common pitfalls:
+
+- **`command not found: x86_64-elf-as` or `x86_64-elf-gccgo`**: Your cross-compiler toolchain is missing or not in your `$PATH`. You must build/install an `x86_64-elf` toolchain natively.
+- **ISO creation fails (`grub-mkrescue` errors)**: The build requires `grub-mkrescue`, `xorriso`, and `mtools` to pack the ISO. Install them via your package manager (e.g., `apt install grub-common grub-pc-bin xorriso mtools`).
+- **QEMU is missing or cannot launch**: Ensure `qemu-system-x86_64` is installed (usually part of the `qemu-system-x86` package). If QEMU fails to launch a display, ensure your host supports graphical windows.
+
+**When in doubt, use the Docker workflow!** It is the recommended path and pre-packages all necessary build dependencies. Just ensure your Docker platform is set to `linux/amd64` (especially important on Apple Silicon Macs).
+
 ## What you’ll see on screen
 
 - On boot the prompt `> ` shows up


### PR DESCRIPTION
## What changed
Added a new "Troubleshooting" section to the README covering missing cross-toolchains, GRUB/ISO tools, and QEMU.

Issue #134 

## Why
To save time for new contributors by documenting common setup pitfalls and highlighting the Docker workflow as a reliable fallback.