### PR TITLE
test(user): verify new syscall ABI for user programs

### DIFF
--- a/kernel/task_runner_test.go
+++ b/kernel/task_runner_test.go
@@ -1,0 +1,33 @@
+package kernel
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestUserHelloUsesSyscallABI(t *testing.T) {
+	// Verifies that user/hello.s uses the new syscall ABI
+	content, err := os.ReadFile("../user/hello.s")
+	if err != nil {
+		t.Fatalf("failed to read hello.s: %v", err)
+	}
+
+	src := string(content)
+	if !strings.Contains(src, "syscall") {
+		t.Error("hello.s should use 'syscall' instruction for the new ABI")
+	}
+	if strings.Contains(src, "int $0x80") || strings.Contains(src, "int 0x80") {
+		t.Error("hello.s should not use the old 'int 0x80' ABI")
+	}
+	
+	// Check for correct register usage for SYS_WRITE (1)
+	if !strings.Contains(src, "mov  $1, %rax") || !strings.Contains(src, "mov  $1, %rdi") {
+		t.Error("hello.s should use %rax for syscall number and %rdi for fd in SYS_WRITE")
+	}
+	
+	// Check for correct register usage for SYS_EXIT (2)
+	if !strings.Contains(src, "mov  $2, %rax") || !strings.Contains(src, "xor  %rdi, %rdi") {
+		t.Error("hello.s should use %rax for syscall number and %rdi for status in SYS_EXIT")
+	}
+}

--- a/kernel/task_runner_test.go
+++ b/kernel/task_runner_test.go
@@ -20,12 +20,12 @@ func TestUserHelloUsesSyscallABI(t *testing.T) {
 	if strings.Contains(src, "int $0x80") || strings.Contains(src, "int 0x80") {
 		t.Error("hello.s should not use the old 'int 0x80' ABI")
 	}
-	
+
 	// Check for correct register usage for SYS_WRITE (1)
 	if !strings.Contains(src, "mov  $1, %rax") || !strings.Contains(src, "mov  $1, %rdi") {
 		t.Error("hello.s should use %rax for syscall number and %rdi for fd in SYS_WRITE")
 	}
-	
+
 	// Check for correct register usage for SYS_EXIT (2)
 	if !strings.Contains(src, "mov  $2, %rax") || !strings.Contains(src, "xor  %rdi, %rdi") {
 		t.Error("hello.s should use %rax for syscall number and %rdi for status in SYS_EXIT")


### PR DESCRIPTION
Resolves #90. This adds a unit test to verify that the `user/hello.s` program correctly implements the new syscall ABI instead of `int 0x80`, using the expected registers for parameters and syscall dispatch.