### PR TITLE
test(user): add ring3 smoke tests and v0.4.0 verification checklist

### DIFF
--- a/boot/stubs_amd64.s
+++ b/boot/stubs_amd64.s
@@ -716,6 +716,17 @@ go_0kernel.GetUserProgramKernelWriteProbeAddr:
 	ret
 .size go_0kernel.GetUserProgramKernelWriteProbeAddr, . - go_0kernel.GetUserProgramKernelWriteProbeAddr
 
+# uint64 go_0kernel.GetUserProgramPrivilegedProbeAddr()
+.global go_0kernel.GetUserProgramPrivilegedProbeAddr
+.type   go_0kernel.GetUserProgramPrivilegedProbeAddr, @function
+go_0kernel.GetUserProgramPrivilegedProbeAddr:
+	leaq go_0kernel.userProbePrivilegedStart(%rip), %rax
+	leaq __user_program_page(%rip), %rdx
+	subq %rdx, %rax
+	addq $USER_VA_BASE, %rax
+	ret
+.size go_0kernel.GetUserProgramPrivilegedProbeAddr, . - go_0kernel.GetUserProgramPrivilegedProbeAddr
+
 # uint64 go_0kernel.GetUserStackTopAddr()
 .global go_0kernel.GetUserStackTopAddr
 .type   go_0kernel.GetUserStackTopAddr, @function

--- a/docs/manual/03-kernel-core/release-checklist.md
+++ b/docs/manual/03-kernel-core/release-checklist.md
@@ -1,0 +1,59 @@
+# Release Checklist for v0.4.0
+
+This checklist provides a quick way to validate that ring3 execution and memory isolation are working as expected before a release.
+
+## 1. Build the OS
+
+Ensure the ISO is built successfully:
+
+```bash
+make clean
+make iso
+```
+
+## 2. Test Normal User Execution
+
+Run QEMU with the newly built ISO:
+
+```bash
+qemu-system-x86_64 -cdrom build/dav-go-os.iso -serial stdio
+```
+
+**Steps:**
+1. Wait for the `DavOS >` prompt.
+2. Run the command: `run hello`
+3. **Expected Output:**
+   - `hello from userland`
+   - `Process exited with status 0`
+   - The shell prompt `> ` should return normally.
+
+## 3. Test Isolation (Kernel Read Fault)
+
+**Steps:**
+1. In the DavOS shell, run: `run kread`
+2. **Expected Output:**
+   - A protection fault (`#PF`) should be triggered.
+   - A `PF` marker should be visible in the debug log.
+   - The QEMU instance should halt (or the kernel should trap and halt as implemented).
+
+## 4. Test Isolation (Kernel Write Fault)
+
+**Steps:**
+1. Restart the OS and at the prompt, run: `run kwrite`
+2. **Expected Output:**
+   - A protection fault (`#PF`) should be triggered.
+   - A `PF` marker should be visible in the debug log.
+   - The QEMU instance should halt.
+
+## 5. Automated Verification
+
+For automated validation, run the boot test suite:
+
+```bash
+python3 scripts/test_boot.py
+```
+
+**Expected Output:**
+- `All QEMU checks passed.`
+
+If all the above tests pass, ring3 execution and kernel memory isolation are functioning correctly.

--- a/kernel/task_runner.go
+++ b/kernel/task_runner.go
@@ -5,11 +5,13 @@ package kernel
 var helloProgramName = [...]byte{'h', 'e', 'l', 'l', 'o'}
 var kernelReadProbeProgramName = [...]byte{'k', 'r', 'e', 'a', 'd'}
 var kernelWriteProbeProgramName = [...]byte{'k', 'w', 'r', 'i', 't', 'e'}
+var privilegedProbeProgramName = [...]byte{'k', 'p', 'r', 'i', 'v'}
 
 func ExecuteUserTask(rip, rsp uint64)
 func GetUserProgramHelloAddr() uint64
 func GetUserProgramKernelReadProbeAddr() uint64
 func GetUserProgramKernelWriteProbeAddr() uint64
+func GetUserProgramPrivilegedProbeAddr() uint64
 func GetUserStackTopAddr() uint64
 
 func RunProgram(name *[16]byte, nameLen int) (pid int, ok bool) {
@@ -21,6 +23,8 @@ func RunProgram(name *[16]byte, nameLen int) (pid int, ok bool) {
 		rip = GetUserProgramKernelReadProbeAddr()
 	case matchProgramName(name, nameLen, kernelWriteProbeProgramName[:]):
 		rip = GetUserProgramKernelWriteProbeAddr()
+	case matchProgramName(name, nameLen, privilegedProbeProgramName[:]):
+		rip = GetUserProgramPrivilegedProbeAddr()
 	default:
 		return -1, false
 	}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,3 +13,4 @@ nav:
   - Privilege Transition: manual/03-kernel-core/privilege-transition-gdt-tss-rsp0.md
   - Syscall Entry And ABI: manual/03-kernel-core/syscall-entry-and-abi.md
   - User/Kernel Memory Isolation: manual/03-kernel-core/user-kernel-memory-isolation.md
+  - Release Checklist: manual/03-kernel-core/release-checklist.md

--- a/scripts/test_boot.py
+++ b/scripts/test_boot.py
@@ -140,7 +140,7 @@ def run_functional_suite(iso_path, disk_img, log_file):
         stop_qemu(process)
 
 
-def run_fault_probe(iso_path, disk_img, cmd_text, log_file):
+def run_fault_probe(iso_path, disk_img, cmd_text, log_file, fault_marker="PF"):
     last_process = None
     for attempt in range(1, 4):
         if os.path.exists(log_file):
@@ -157,14 +157,14 @@ def run_fault_probe(iso_path, disk_img, cmd_text, log_file):
             print("Boot successful.")
             send_shell_command(process, cmd_text)
 
-            print("Waiting for ring3 protection fault marker ('PF')...")
-            if not check_log_for("PF", log_file, timeout=6):
+            print(f"Waiting for ring3 protection fault marker ('{fault_marker}')...")
+            if not check_log_for(fault_marker, log_file, timeout=6):
                 fail_with_log(
-                    f"Did not observe PF marker after '{cmd_text}'.",
+                    f"Did not observe {fault_marker} marker after '{cmd_text}'.",
                     process,
                     log_file,
                 )
-            print(f"Test Passed: '{cmd_text}' triggered PF as expected.")
+            print(f"Test Passed: '{cmd_text}' triggered {fault_marker} as expected.")
             return
         finally:
             stop_qemu(process)
@@ -193,10 +193,13 @@ def main():
     # Each probe must run in its own VM instance because a #PF is terminal here.
     kread_disk = "disk_kread.img"
     kwrite_disk = "disk_kwrite.img"
+    kpriv_disk = "disk_kpriv.img"
     create_disk_image(kread_disk)
     create_disk_image(kwrite_disk)
-    run_fault_probe(iso_path, kread_disk, "run kread", "qemu_kread.log")
-    run_fault_probe(iso_path, kwrite_disk, "run kwrite", "qemu_kwrite.log")
+    create_disk_image(kpriv_disk)
+    run_fault_probe(iso_path, kread_disk, "run kread", "qemu_kread.log", "PF")
+    run_fault_probe(iso_path, kwrite_disk, "run kwrite", "qemu_kwrite.log", "PF")
+    run_fault_probe(iso_path, kpriv_disk, "run kpriv", "qemu_kpriv.log", "GP")
 
     print("All QEMU checks passed.")
 

--- a/user/hello.s
+++ b/user/hello.s
@@ -43,3 +43,8 @@ hello_msg:
 	.ascii "hello from userland\n"
 hello_msg_end:
 	.set hello_msg_len, hello_msg_end - hello_msg
+
+.global go_0kernel.userProbePrivilegedStart
+go_0kernel.userProbePrivilegedStart:
+	cli              # Privileged instruction, must #GP in ring 3
+	hlt


### PR DESCRIPTION
Resolves #91. This adds a user-mode privileged instruction fault test (kpriv) that ensures `cli` correctly faults in ring3 and is caught by the kernel. Additionally, it provides a comprehensive release checklist for v0.4.0 in the documentation, detailing manual verification steps for both QEMU execution and Python automated tests.