### PR TITLE
feat(scripts/test_boot): add --functional / --fault-probes selection flags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,10 @@ go test ./fs ./kernel/scheduler ./kernel/gdt ./kernel/tss
 
 # Run integration tests (requires QEMU)
 python3 scripts/test_boot.py
+
+# Iterate on one class of behavior:
+python3 scripts/test_boot.py --functional      # only the shell suite
+python3 scripts/test_boot.py --fault-probes    # only the kread/kwrite/kpriv probes
 ```
 
 All tests must pass in CI. The `make test` command automatically discovers and runs all packages containing `*_test.go` files.

--- a/scripts/test_boot.py
+++ b/scripts/test_boot.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import subprocess
 import sys
@@ -177,29 +178,53 @@ def run_fault_probe(iso_path, disk_img, cmd_text, log_file, fault_marker="PF"):
     )
 
 
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Run QEMU boot verification for DavOS.",
+    )
+    suite = parser.add_mutually_exclusive_group()
+    suite.add_argument(
+        "--functional",
+        action="store_true",
+        help="Run only the functional shell suite (skip fault probes).",
+    )
+    suite.add_argument(
+        "--fault-probes",
+        action="store_true",
+        help="Run only the kread / kwrite / kpriv fault probes (skip the functional suite).",
+    )
+    return parser.parse_args()
+
+
 def main():
+    args = parse_args()
+    run_functional = not args.fault_probes
+    run_faults = not args.functional
+
     iso_path = "build/dav-go-os.iso"
-    disk_img = "disk.img"
 
     if not os.path.exists(iso_path):
         print(f"ERROR: ISO not found at {iso_path}. Build it first.")
         sys.exit(1)
 
-    create_disk_image(disk_img)
-
     print(f"Starting QEMU verification for {iso_path}...")
-    run_functional_suite(iso_path, disk_img, "qemu.log")
 
-    # Each probe must run in its own VM instance because a #PF is terminal here.
-    kread_disk = "disk_kread.img"
-    kwrite_disk = "disk_kwrite.img"
-    kpriv_disk = "disk_kpriv.img"
-    create_disk_image(kread_disk)
-    create_disk_image(kwrite_disk)
-    create_disk_image(kpriv_disk)
-    run_fault_probe(iso_path, kread_disk, "run kread", "qemu_kread.log", "PF")
-    run_fault_probe(iso_path, kwrite_disk, "run kwrite", "qemu_kwrite.log", "PF")
-    run_fault_probe(iso_path, kpriv_disk, "run kpriv", "qemu_kpriv.log", "GP")
+    if run_functional:
+        disk_img = "disk.img"
+        create_disk_image(disk_img)
+        run_functional_suite(iso_path, disk_img, "qemu.log")
+
+    if run_faults:
+        # Each probe must run in its own VM instance because a #PF is terminal here.
+        kread_disk = "disk_kread.img"
+        kwrite_disk = "disk_kwrite.img"
+        kpriv_disk = "disk_kpriv.img"
+        create_disk_image(kread_disk)
+        create_disk_image(kwrite_disk)
+        create_disk_image(kpriv_disk)
+        run_fault_probe(iso_path, kread_disk, "run kread", "qemu_kread.log", "PF")
+        run_fault_probe(iso_path, kwrite_disk, "run kwrite", "qemu_kwrite.log", "PF")
+        run_fault_probe(iso_path, kpriv_disk, "run kpriv", "qemu_kpriv.log", "GP")
 
     print("All QEMU checks passed.")
 


### PR DESCRIPTION
Closes #135.

Adds optional selection flags on `scripts/test_boot.py` so contributors can iterate on one class of behavior:

- `python3 scripts/test_boot.py --functional` runs only the shell suite (help, version, fatformat, fatinit, fatcreate, fatls, fatread, run hello).
- `python3 scripts/test_boot.py --fault-probes` runs only the kread / kwrite / kpriv fault probes.
- With neither flag, the script runs both suites - matching today's CI behavior.

The two flags are mutually exclusive via argparse, so `--help` documents the choice clearly. Disk images for the unselected suite are not allocated, which keeps fast iteration cheap.

CI calls `python3 scripts/test_boot.py` with no flags (`.github/workflows/build-and-run.yml`), so default behavior is preserved.

CONTRIBUTING.md has been updated with the new invocations alongside the existing `python3 scripts/test_boot.py` line.