### PR TITLE
feat(scripts): add --functional-only and --fault-only flags to test_boot.py

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,12 @@ go test ./fs ./kernel/scheduler ./kernel/gdt ./kernel/tss
 
 # Run integration tests (requires QEMU)
 python3 scripts/test_boot.py
+
+# Or run only the functional shell suite
+python3 scripts/test_boot.py --functional-only
+
+# Or run only the fault probes (kread, kwrite, kpriv)
+python3 scripts/test_boot.py --fault-only
 ```
 
 All tests must pass in CI. The `make test` command automatically discovers and runs all packages containing `*_test.go` files.

--- a/scripts/test_boot.py
+++ b/scripts/test_boot.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import subprocess
 import sys
@@ -177,7 +178,33 @@ def run_fault_probe(iso_path, disk_img, cmd_text, log_file, fault_marker="PF"):
     )
 
 
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run the QEMU-based boot verification for go-dav-os. "
+            "By default, runs the full functional shell suite followed by the "
+            "fault probes (kread, kwrite, kpriv)."
+        ),
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--functional-only",
+        action="store_true",
+        help="Run only the functional shell suite; skip the fault probes.",
+    )
+    group.add_argument(
+        "--fault-only",
+        action="store_true",
+        help="Run only the fault probes (kread, kwrite, kpriv); skip the functional suite.",
+    )
+    return parser.parse_args(argv)
+
+
 def main():
+    args = parse_args()
+    run_functional = not args.fault_only
+    run_fault = not args.functional_only
+
     iso_path = "build/dav-go-os.iso"
     disk_img = "disk.img"
 
@@ -185,21 +212,22 @@ def main():
         print(f"ERROR: ISO not found at {iso_path}. Build it first.")
         sys.exit(1)
 
-    create_disk_image(disk_img)
+    if run_functional:
+        create_disk_image(disk_img)
+        print(f"Starting QEMU verification for {iso_path}...")
+        run_functional_suite(iso_path, disk_img, "qemu.log")
 
-    print(f"Starting QEMU verification for {iso_path}...")
-    run_functional_suite(iso_path, disk_img, "qemu.log")
-
-    # Each probe must run in its own VM instance because a #PF is terminal here.
-    kread_disk = "disk_kread.img"
-    kwrite_disk = "disk_kwrite.img"
-    kpriv_disk = "disk_kpriv.img"
-    create_disk_image(kread_disk)
-    create_disk_image(kwrite_disk)
-    create_disk_image(kpriv_disk)
-    run_fault_probe(iso_path, kread_disk, "run kread", "qemu_kread.log", "PF")
-    run_fault_probe(iso_path, kwrite_disk, "run kwrite", "qemu_kwrite.log", "PF")
-    run_fault_probe(iso_path, kpriv_disk, "run kpriv", "qemu_kpriv.log", "GP")
+    if run_fault:
+        # Each probe must run in its own VM instance because a #PF is terminal here.
+        kread_disk = "disk_kread.img"
+        kwrite_disk = "disk_kwrite.img"
+        kpriv_disk = "disk_kpriv.img"
+        create_disk_image(kread_disk)
+        create_disk_image(kwrite_disk)
+        create_disk_image(kpriv_disk)
+        run_fault_probe(iso_path, kread_disk, "run kread", "qemu_kread.log", "PF")
+        run_fault_probe(iso_path, kwrite_disk, "run kwrite", "qemu_kwrite.log", "PF")
+        run_fault_probe(iso_path, kpriv_disk, "run kpriv", "qemu_kpriv.log", "GP")
 
     print("All QEMU checks passed.")
 


### PR DESCRIPTION
Closes #135

## What changed

`scripts/test_boot.py` now takes optional CLI flags so contributors can run only one class of QEMU check while iterating:

- `--functional-only` runs the shell suite (`help`, `version`, `fatformat`, etc.) and skips the kread/kwrite/kpriv fault probes.
- `--fault-only` runs only the three fault probes and skips the shell suite.
- The default (no flags) is unchanged: full functional suite, then all fault probes.

The two flags are mutually exclusive (`argparse` enforces this), and `--help` describes both options plus the default behavior.

## Why

Per the issue, the script always runs everything end-to-end. When you're iterating on one specific behavior, that's a lot of QEMU lifecycle to wait through. These flags keep the default verification flow intact (CI keeps calling `python3 scripts/test_boot.py` with no arguments) while giving contributors a faster local feedback loop.

## How to test

```bash
# Default - unchanged behavior, runs everything
python3 scripts/test_boot.py

# Just the shell suite
python3 scripts/test_boot.py --functional-only

# Just the fault probes
python3 scripts/test_boot.py --fault-only

# Help text
python3 scripts/test_boot.py --help
```

The `--help` and parse_args branches were also unit-checked locally with each flag combination, including the mutual-exclusion case (which exits with usage text as expected).

## Other notes

- `CONTRIBUTING.md` "Testing" section now lists all three invocations next to the existing `python3 scripts/test_boot.py` line.
- No new dependencies; `argparse` is stdlib.
- The functional helpers (`run_functional_suite`, `run_fault_probe`, `start_qemu`, etc.) are untouched - the only change in `main()` is gating the two phases on the parsed flags.
