### PR TITLE
docs: add AGENTS.md, REVIEW.md, and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+<!-- Reviewer's checklist lives in REVIEW.md. AGENTS.md covers expectations for AI-authored PRs. -->
+
+## What
+
+<!-- One or two lines: what does this change? -->
+
+## Why
+
+<!-- One or two lines: why does it need to change? Link to the issue if there is one. -->
+
+Closes #
+
+## How to test
+
+<!-- A concrete command (or sequence) the reviewer can run to verify the change. Example:
+- `make test`
+- `python3 scripts/test_boot.py --functional`
+- Boot in QEMU and run `<command>` in the shell, expect `<output>`.
+-->
+
+## Pre-flight
+
+- [ ] `gofmt -l .` prints nothing
+- [ ] `go vet -tags testing -unsafeptr=false ./...` is clean
+- [ ] `make test` passes
+- [ ] `python3 scripts/test_boot.py` passes
+- [ ] PR is a single concern (no drive-by cleanups)
+
+<!-- If AI was used substantially in this PR, leave one line below: "AI was used for assistance." -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# Guide for Coding Agents
+
+This file gives coding agents (Claude Code, Codex, Copilot, Cursor, automated PR bots, etc.) the rules and context they need to ship good changes to **go-dav-os**.
+
+If you are a human, you do not need to read this — start with [`README.md`](README.md) and [`CONTRIBUTING.md`](CONTRIBUTING.md). The same expectations apply to agent-authored PRs.
+
+## Project shape
+
+go-dav-os is a 64-bit freestanding hobby kernel written in Go (`gccgo`, x86_64 long mode), booted via GRUB/Multiboot2. Kernel-only — bootloader and BIOS are delegated to existing tools. Top-level packages: `boot/`, `kernel/`, `terminal/`, `keyboard/`, `mem/`, `fs/`, `drivers/ata`, `fs/fat16`, `shell/`, `user/`. Build via `make`/`make iso`/`make run`. CI runs `gofmt -l .`, `go vet -tags testing -unsafeptr=false ./...`, and `make test` plus `python3 scripts/test_boot.py`.
+
+## Hard rules for agents
+
+1. **Stay minimal.** This is a hobby kernel. Don't refactor adjacent code, don't add abstractions you don't need, don't introduce dependencies. The maintainer's stated bar is "minimal but usable". Three repeated lines beat a premature helper.
+2. **One concern per PR.** No "while I'm here I cleaned up X". Tangential cleanups belong in their own PR.
+3. **Run the gates the human reviewer runs.** Before opening a PR, confirm:
+   - `gofmt -l .` prints nothing
+   - `go vet -tags testing -unsafeptr=false ./...` is clean
+   - `make test` passes
+   - `python3 scripts/test_boot.py` passes (the QEMU integration suite)
+4. **Don't touch `boot/boot.s`, the Multiboot2 header layout, or paging/IDT setup unless the issue is explicitly about them.** Those are load-bearing.
+5. **No standard library imports in kernel code.** This is a freestanding build (`gccgo`, no stdlib). Stick to packages already imported in the file you're editing.
+6. **Comments explain *why*, not *what*.** Identifier names already say what; only comment when the reasoning would otherwise be lost.
+7. **Disclose AI authorship in the PR body** when the change was substantially agent-written. One line is enough: `AI was used for assistance.` Do not advertise the engine name or describe verification — keep it short.
+
+## Recommended workflow
+
+1. Read the issue all the way through. If it lists numbered acceptance criteria, your PR must close every one of them or you should not open the PR yet.
+2. Open the relevant file before changing it. Match the existing style of that file (indentation, comment density, error-handling shape).
+3. Keep diffs small. Aim for under 100 added lines on a first contribution.
+4. Run the full gate stack locally. If a gate fails, fix it locally — do not push and let CI fail.
+5. Follow the [PR template](.github/pull_request_template.md). Three lines (what / why / how to test) is the minimum, not a suggestion.
+
+## Things that get auto-rejected
+
+- PRs that fail `gofmt` or `go vet`.
+- PRs that bundle unrelated cleanups with the actual fix.
+- PRs that import new third-party Go modules into kernel code.
+- PRs that add `TODO`/`FIXME` comments without an issue link.
+- PRs whose body is generic AI-style boilerplate ("This PR adds robust support for...") instead of a concrete what/why/how-to-test.
+
+## Review
+
+Every PR — agent-authored or human-authored — is judged against [`REVIEW.md`](REVIEW.md). Read it before opening the PR; if your change can't pass that checklist, rework it before pushing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ This is a hobby project and it’s still in a very early stage. The main idea is
 
 If you’re not sure where to start, open a Discussion and we’ll align quickly.
 
+Reviewers run [`REVIEW.md`](REVIEW.md) on every PR; coding agents (Claude Code, Codex, Cursor, automated PR bots) should also read [`AGENTS.md`](AGENTS.md) before opening a PR.
+
 ## What you can contribute
 Anything that helps the project move forward, especially:
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,49 @@
+# PR Review Checklist
+
+This file gives reviewers (and contributors) a lightweight quality gate to run on every PR — human or automated. Tick each item before approving or merging.
+
+If a PR can't tick the relevant items, it is either re-worked or closed.
+
+## Build and tests
+
+- [ ] `gofmt -l .` is empty (zero unformatted files)
+- [ ] `go vet -tags testing -unsafeptr=false ./...` reports no issues
+- [ ] `make test` passes locally
+- [ ] `python3 scripts/test_boot.py` passes (QEMU integration suite)
+- [ ] CI on the PR is green
+
+## Scope and shape
+
+- [ ] PR closes a specific issue or has a clear scope statement (no "drive-by" changes)
+- [ ] Diff is local — does not touch unrelated files
+- [ ] Diff size is justified by the change — no incidental refactors
+- [ ] No new third-party Go modules added to kernel code
+- [ ] No new standard-library imports in freestanding kernel packages
+
+## Code quality
+
+- [ ] Identifier names explain what each function/variable does
+- [ ] Comments explain *why*, not *what*
+- [ ] Error handling matches the surrounding file (no new patterns introduced silently)
+- [ ] No `TODO` / `FIXME` markers without a linked issue
+- [ ] `boot/boot.s`, Multiboot2 header, paging, and IDT setup are untouched (unless the PR is explicitly about them)
+
+## Tests for behavior changes
+
+- [ ] If the PR changes behavior, there is a test that fails on `main` and passes on the branch
+- [ ] If the PR changes shell / boot output, the relevant `test_boot.py` case is updated
+- [ ] If the PR changes a public API in a Go package, the package's `*_test.go` is updated
+
+## PR description
+
+- [ ] PR body has the three sections from [`pull_request_template.md`](.github/pull_request_template.md): **what**, **why**, **how to test**
+- [ ] "How to test" has a concrete command, not a description
+- [ ] If AI was used substantially, the PR body includes the disclosure line `AI was used for assistance.`
+- [ ] If the PR was opened from a coding agent, the agent followed [`AGENTS.md`](AGENTS.md)
+
+## Final gate
+
+- [ ] Reviewer can answer "what did this PR change?" in one sentence
+- [ ] Reviewer can answer "what would break if I revert this PR?" in one sentence
+
+If both answers are easy, the PR is ready to merge.


### PR DESCRIPTION
<!-- Reviewer's checklist lives in REVIEW.md. AGENTS.md covers expectations for AI-authored PRs. -->

## What

Resolves #146. Adds the three docs the issue asked for plus the cross-link from `CONTRIBUTING.md`:

- `AGENTS.md` — rules and repo-specific context for coding agents.
- `REVIEW.md` — lightweight reviewer checklist for every PR.
- `.github/pull_request_template.md` — short three-section template (what / why / how to test) with a pre-flight checklist matching the CI gates.
- `CONTRIBUTING.md` — one cross-reference line near the top so the new docs are discoverable.

## Why

#146 lays out the reasoning: standardise how coding agents contribute, and give automated PRs a quality bar to clear. The three files lock in the gates already implied by `CONTRIBUTING.md` (`gofmt`, `go vet`, `make test`, `scripts/test_boot.py`) and call out the freestanding-build constraint plus the "no drive-by refactors" rule that newer agents tend to ignore.

I read `CONTRIBUTING.md`, the existing CI workflows (`.github/workflows/build-and-run.yml`, `docs.yml`), and the `make` targets to keep the gate list accurate to what already runs. AGENTS.md and REVIEW.md both reference those gates by name so an agent can replicate them without guessing.

Closes #146

## How to test

- Open the PR — GitHub picks up `.github/pull_request_template.md` automatically and pre-fills the description for the next contributor. (This very PR uses the template per the "At least one PR is opened using the new template" acceptance criterion.)
- `cat AGENTS.md`, `cat REVIEW.md`, `cat .github/pull_request_template.md` — verify the three deliverables landed and contain repo-specific rules, not generic boilerplate.
- `grep -E "AGENTS|REVIEW" CONTRIBUTING.md` — confirms the cross-link line exists at the top of CONTRIBUTING.md.

## Pre-flight

- [x] `gofmt -l .` prints nothing (no Go files touched)
- [x] `go vet -tags testing -unsafeptr=false ./...` is clean (no Go files touched)
- [x] `make test` passes (no Go files touched)
- [x] `python3 scripts/test_boot.py` passes (no kernel/scripts/* files touched)
- [x] PR is a single concern (only the four files listed above)

AI was used for assistance.
