### PR TITLE
scripts: add layout smoke coverage to test_boot.py (closes #130)

### DIFF
--- a/scripts/test_boot.py
+++ b/scripts/test_boot.py
@@ -123,6 +123,9 @@ def run_functional_suite(iso_path, disk_img, log_file):
             ("fatcreate test hi", ["File created"]),
             ("fatls", ["TEST"]),
             ("fatread test", ["hi"]),
+            ("layout", ["current layout:"]),
+            ("layout us", ["layout: switched to us"]),
+            ("layout it", ["layout: switched to it"]),
             ("run hello", ["hello from userland", "Process exited with status 0"]),
         ]
 


### PR DESCRIPTION
## What

Adds three QEMU smoke cases for the `layout` shell command to `scripts/test_boot.py`: bare invocation prints `current layout:`, `layout us` prints `layout: switched to us`, `layout it` prints `layout: switched to it`.

## Why

Closes #130

The layout switcher is user-visible shell behavior that has no smoke coverage today. The issue asks for the cases to be added to the existing functional suite without spinning up a new QEMU instance.

## How to test

- `python3 scripts/test_boot.py --functional`

The new entries are appended to the `test_cases` list in `run_functional_suite`, so they run inside the same QEMU session as `help`/`version`/`fatcreate` etc. After `layout it` runs the keyboard returns to the project's default IT layout, leaving the session in the same state the next test expects.

## Pre-flight

- [x] `gofmt -l .` prints nothing
- [x] `go vet -tags testing -unsafeptr=false ./...` is clean
- [ ] `make test` passes (failures observed are pre-existing on this Mac toolchain; the project targets gccgo/x86_64 Linux freestanding, not host-arm64. CI on the project's x86_64 Linux runners will exercise the gates.)
- [ ] `python3 scripts/test_boot.py` passes (requires QEMU and a built ISO; not available in my environment, see line above)
- [x] PR is a single concern (no drive-by cleanups)

AI was used for assistance.
