### PR TITLE
Creating the agent runtime architecture

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -289,6 +289,7 @@ func TestDeterministicPlannerRecognizesHelpAndDefaultsSafely(t *testing.T) {
 	}{
 		{input: "HELP", intent: IntentShowHelp, action: ActionShowHelp},
 		{input: "what can you do?", intent: IntentShowHelp, action: ActionShowHelp},
+		{input: "help with files", intent: IntentShowHelp, action: ActionShowHelp},
 		{input: "LS", intent: IntentListFiles, action: ActionListFiles},
 	}
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -93,17 +93,17 @@ func TestLLMPlannerFailsWithoutBridge(t *testing.T) {
 	if result.OK {
 		t.Fatalf("expected missing bridge to fail")
 	}
-	if result.Reason != "agent: llm bridge not configured" {
+	if result.Reason != errLLMBridgeNotConfigured {
 		t.Fatalf("unexpected failure reason: %q", result.Reason)
 	}
 }
 
 func TestRuntimeReturnsPlannerError(t *testing.T) {
-	response := Runtime{Planner: failingPlanner{reason: "agent: llm bridge not configured"}}.Run("show files", nil)
+	response := Runtime{Planner: failingPlanner{reason: errLLMBridgeNotConfigured}}.Run("show files", nil)
 	if response.Result.OK {
 		t.Fatalf("expected planner failure response")
 	}
-	if response.Result.Message != "agent: llm bridge not configured" {
+	if response.Result.Message != errLLMBridgeNotConfigured {
 		t.Fatalf("unexpected planner failure message: %q", response.Result.Message)
 	}
 	if response.Safety.Status != SafetyRejected {
@@ -346,13 +346,13 @@ func TestContextRememberRollsRecentItems(t *testing.T) {
 }
 
 func TestEnumStrings(t *testing.T) {
-	if PlannerModeDeterministic.String() != "deterministic" || PlannerModeLLM.String() != "llm" || PlannerMode(99).String() != "unknown" {
+	if PlannerModeDeterministic.String() != "deterministic" || PlannerModeLLM.String() != "llm" || PlannerMode(99).String() != stringUnknown {
 		t.Fatalf("unexpected planner mode strings")
 	}
-	if IntentReadFile.String() != "read_file" || IntentWriteFile.String() != "write_file" || IntentDeleteFile.String() != "delete_file" || IntentKind(99).String() != "unknown" {
+	if IntentReadFile.String() != stringReadFile || IntentWriteFile.String() != stringWriteFile || IntentDeleteFile.String() != stringDeleteFile || IntentKind(99).String() != stringUnknown {
 		t.Fatalf("unexpected intent strings")
 	}
-	if ActionNone.String() != "none" || ActionDeleteFile.String() != "delete_file" || ActionKind(99).String() != "none" {
+	if ActionNone.String() != stringNone || ActionDeleteFile.String() != stringDeleteFile || ActionKind(99).String() != stringNone {
 		t.Fatalf("unexpected action strings")
 	}
 	if RiskSafe.String() != "safe" || RiskRisky.String() != "risky" {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,0 +1,403 @@
+package agent
+
+import "testing"
+
+func TestRuntimeExecutesTypedSafePlan(t *testing.T) {
+	executed := false
+	runtime := Runtime{
+		Planner: DeterministicPlanner{},
+		Executor: AllowedActionExecutor{
+			ListFiles: func(action Action, context *Context) ActionResult {
+				executed = true
+				if action.Kind != ActionListFiles {
+					t.Fatalf("unexpected action kind: %v", action.Kind)
+				}
+				return ActionResult{OK: true, Message: "files listed"}
+			},
+		},
+	}
+
+	var context Context
+	response := runtime.Run("show files", &context)
+	if !response.Result.OK {
+		t.Fatalf("expected successful response, got %q", response.Result.Message)
+	}
+	if !executed {
+		t.Fatalf("expected executor to run")
+	}
+	if response.Safety.Status != SafetyAllowed {
+		t.Fatalf("expected safety allowed, got %v", response.Safety.Status)
+	}
+	if context.LastIntent != IntentListFiles {
+		t.Fatalf("expected context to remember list intent, got %v", context.LastIntent)
+	}
+}
+
+func TestRuntimeRequiresConfirmationForRiskyPlan(t *testing.T) {
+	executed := false
+	runtime := Runtime{
+		Planner: staticPlanner{plan: singleActionPlan(PlannerModeLLM, IntentDeleteFile, ActionDeleteFile, RiskRisky)},
+		Executor: AllowedActionExecutor{
+			DeleteFile: func(action Action, context *Context) ActionResult {
+				executed = true
+				return ActionResult{OK: true, Message: "deleted"}
+			},
+		},
+	}
+
+	response := runtime.Run("delete notes", nil)
+	if response.Safety.Status != SafetyConfirmationRequired {
+		t.Fatalf("expected confirmation_required, got %v", response.Safety.Status)
+	}
+	if response.Result.OK {
+		t.Fatalf("expected response to stop before execution")
+	}
+	if executed {
+		t.Fatalf("risky action executed without confirmation")
+	}
+}
+
+func TestValidatorRejectsUnsupportedActionKinds(t *testing.T) {
+	plan := singleActionPlan(PlannerModeLLM, IntentUnknown, ActionKind(99), RiskSafe)
+	result := DefaultValidator{}.Validate(plan)
+	if result.OK {
+		t.Fatalf("expected unsupported action to be rejected")
+	}
+}
+
+func TestValidatorRejectsUnsupportedRiskLevels(t *testing.T) {
+	plan := singleActionPlan(PlannerModeLLM, IntentDeleteFile, ActionDeleteFile, RiskLevel(99))
+	result := DefaultValidator{}.Validate(plan)
+	if result.OK {
+		t.Fatalf("expected unsupported risk to be rejected")
+	}
+}
+
+func TestLLMPlannerDelegatesToBridge(t *testing.T) {
+	bridge := fakeBridge{plan: singleActionPlan(PlannerModeDeterministic, IntentStatFile, ActionStatFile, RiskSafe)}
+	result := LLMPlanner{Bridge: bridge}.Plan("status of notes", nil)
+	if !result.OK {
+		t.Fatalf("expected LLM planner to succeed, got %q", result.Reason)
+	}
+	plan := result.Plan
+	if plan.Planner != PlannerModeLLM {
+		t.Fatalf("expected LLM planner mode, got %v", plan.Planner)
+	}
+	if plan.Intent != IntentStatFile {
+		t.Fatalf("expected bridge intent, got %v", plan.Intent)
+	}
+}
+
+func TestLLMPlannerFailsWithoutBridge(t *testing.T) {
+	result := LLMPlanner{}.Plan("show files", nil)
+	if result.OK {
+		t.Fatalf("expected missing bridge to fail")
+	}
+	if result.Reason != "agent: llm bridge not configured" {
+		t.Fatalf("unexpected failure reason: %q", result.Reason)
+	}
+}
+
+func TestRuntimeReturnsPlannerError(t *testing.T) {
+	response := Runtime{Planner: failingPlanner{reason: "agent: llm bridge not configured"}}.Run("show files", nil)
+	if response.Result.OK {
+		t.Fatalf("expected planner failure response")
+	}
+	if response.Result.Message != "agent: llm bridge not configured" {
+		t.Fatalf("unexpected planner failure message: %q", response.Result.Message)
+	}
+	if response.Safety.Status != SafetyRejected {
+		t.Fatalf("expected rejected safety status, got %v", response.Safety.Status)
+	}
+}
+
+func TestRuntimeReturnsDefaultPlannerError(t *testing.T) {
+	response := Runtime{Planner: failingPlanner{}}.Run("show files", nil)
+	if response.Result.Message != "agent: planner failed" {
+		t.Fatalf("unexpected planner failure message: %q", response.Result.Message)
+	}
+	if response.TraceCount != 1 || response.Trace[0].Stage != "Planner" {
+		t.Fatalf("expected planner trace, got count=%d", response.TraceCount)
+	}
+}
+
+func TestRuntimeRejectsMissingPlanner(t *testing.T) {
+	response := Runtime{}.Run("show files", nil)
+	if response.Result.OK {
+		t.Fatalf("expected missing planner to fail")
+	}
+	if response.Safety.Reason != "planner_missing" {
+		t.Fatalf("unexpected safety reason: %q", response.Safety.Reason)
+	}
+}
+
+func TestRuntimeStopsOnValidationFailure(t *testing.T) {
+	executed := false
+	response := Runtime{
+		Planner: staticPlanner{plan: Plan{}},
+		Executor: AllowedActionExecutor{
+			ShowHelp: func(action Action, context *Context) ActionResult {
+				executed = true
+				return ActionResult{OK: true, Message: "help"}
+			},
+		},
+	}.Run("invalid", nil)
+
+	if response.Result.OK {
+		t.Fatalf("expected validation failure")
+	}
+	if response.Safety.Reason != "validation_failed" {
+		t.Fatalf("unexpected safety reason: %q", response.Safety.Reason)
+	}
+	if executed {
+		t.Fatalf("executor ran after validation failure")
+	}
+}
+
+func TestRuntimeReportsMissingExecutor(t *testing.T) {
+	response := Runtime{
+		Planner: staticPlanner{plan: singleActionPlan(PlannerModeDeterministic, IntentShowHelp, ActionShowHelp, RiskSafe)},
+	}.Run("help", nil)
+
+	if response.Result.Message != "agent: executor not configured" {
+		t.Fatalf("unexpected missing executor message: %q", response.Result.Message)
+	}
+}
+
+func TestRuntimeStopsOnExecutorFailure(t *testing.T) {
+	response := Runtime{
+		Planner: staticPlanner{plan: singleActionPlan(PlannerModeDeterministic, IntentReadFile, ActionReadFile, RiskSafe)},
+		Executor: AllowedActionExecutor{
+			ReadFile: func(action Action, context *Context) ActionResult {
+				return ActionResult{OK: false, Message: "read failed"}
+			},
+		},
+	}.Run("read notes", nil)
+
+	if response.Result.OK {
+		t.Fatalf("expected executor failure")
+	}
+	if response.Result.Message != "read failed" {
+		t.Fatalf("unexpected executor failure: %q", response.Result.Message)
+	}
+}
+
+func TestAllowedActionExecutorFailsClosed(t *testing.T) {
+	result := AllowedActionExecutor{}.Execute(Action{Kind: ActionReadFile}, nil)
+	if result.OK {
+		t.Fatalf("expected unavailable action to fail")
+	}
+}
+
+func TestAllowedActionExecutorDispatchesAllActions(t *testing.T) {
+	calls := 0
+	handler := func(expected ActionKind) ActionHandler {
+		return func(action Action, context *Context) ActionResult {
+			calls++
+			if action.Kind != expected {
+				t.Fatalf("expected action %v, got %v", expected, action.Kind)
+			}
+			return ActionResult{OK: true, Message: action.Kind.String()}
+		}
+	}
+
+	executor := AllowedActionExecutor{
+		ListFiles:  handler(ActionListFiles),
+		ReadFile:   handler(ActionReadFile),
+		WriteFile:  handler(ActionWriteFile),
+		DeleteFile: handler(ActionDeleteFile),
+		StatFile:   handler(ActionStatFile),
+		ShowHelp:   handler(ActionShowHelp),
+	}
+
+	actions := [...]ActionKind{
+		ActionListFiles,
+		ActionReadFile,
+		ActionWriteFile,
+		ActionDeleteFile,
+		ActionStatFile,
+		ActionShowHelp,
+	}
+	for _, kind := range actions {
+		result := executor.Execute(Action{Kind: kind}, nil)
+		if !result.OK {
+			t.Fatalf("expected action %v to succeed: %q", kind, result.Message)
+		}
+	}
+	if calls != len(actions) {
+		t.Fatalf("expected %d calls, got %d", len(actions), calls)
+	}
+}
+
+func TestAllowedActionExecutorRejectsUnknownAction(t *testing.T) {
+	result := AllowedActionExecutor{}.Execute(Action{Kind: ActionKind(99)}, nil)
+	if result.OK {
+		t.Fatalf("expected unknown action to fail")
+	}
+	if result.Message != "agent: unsupported action" {
+		t.Fatalf("unexpected result: %q", result.Message)
+	}
+}
+
+func TestDefaultValidatorRejectsMalformedPlans(t *testing.T) {
+	tests := []struct {
+		name string
+		plan Plan
+	}{
+		{name: "no actions", plan: Plan{}},
+		{name: "too many actions", plan: Plan{ActionCount: MaxActions + 1}},
+		{name: "target too long", plan: planWithAction(Action{Kind: ActionReadFile, Risk: RiskSafe, TargetLen: MaxNameLen + 1})},
+		{name: "negative target", plan: planWithAction(Action{Kind: ActionReadFile, Risk: RiskSafe, TargetLen: -1})},
+		{name: "data too long", plan: planWithAction(Action{Kind: ActionWriteFile, Risk: RiskSafe, DataLen: MaxDataLen + 1})},
+		{name: "negative data", plan: planWithAction(Action{Kind: ActionWriteFile, Risk: RiskSafe, DataLen: -1})},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DefaultValidator{}.Validate(tt.plan)
+			if result.OK {
+				t.Fatalf("expected malformed plan to be rejected")
+			}
+		})
+	}
+}
+
+func TestDefaultFormatter(t *testing.T) {
+	var results [MaxActions]ActionResult
+	formatter := DefaultFormatter{}
+
+	if result := formatter.Format(Plan{}, results, 0, SafetyDecision{}); result.OK {
+		t.Fatalf("expected no-result format to fail")
+	}
+
+	results[0] = ActionResult{OK: true, Message: "one"}
+	if result := formatter.Format(Plan{}, results, 1, SafetyDecision{}); result.Message != "one" {
+		t.Fatalf("expected single result message, got %q", result.Message)
+	}
+
+	results[1] = ActionResult{OK: true, Message: "two"}
+	if result := formatter.Format(Plan{}, results, 2, SafetyDecision{}); !result.OK || result.Message != "agent: completed plan" {
+		t.Fatalf("unexpected multi result: %+v", result)
+	}
+}
+
+func TestDeterministicPlannerRecognizesHelpAndDefaultsSafely(t *testing.T) {
+	tests := []struct {
+		input  string
+		intent IntentKind
+		action ActionKind
+	}{
+		{input: "HELP", intent: IntentShowHelp, action: ActionShowHelp},
+		{input: "what can you do?", intent: IntentShowHelp, action: ActionShowHelp},
+		{input: "LS", intent: IntentListFiles, action: ActionListFiles},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := DeterministicPlanner{}.Plan(tt.input, nil)
+			if !result.OK {
+				t.Fatalf("expected deterministic plan to succeed")
+			}
+			if result.Plan.Intent != tt.intent || result.Plan.Actions[0].Kind != tt.action {
+				t.Fatalf("unexpected plan: intent=%v action=%v", result.Plan.Intent, result.Plan.Actions[0].Kind)
+			}
+		})
+	}
+}
+
+func TestLLMPlannerPropagatesBridgeFailure(t *testing.T) {
+	result := LLMPlanner{Bridge: failingBridge{reason: "bridge timeout"}}.Plan("show files", nil)
+	if result.OK {
+		t.Fatalf("expected bridge failure")
+	}
+	if result.Reason != "bridge timeout" {
+		t.Fatalf("unexpected bridge failure: %q", result.Reason)
+	}
+}
+
+func TestLLMPlannerDefaultsEmptyBridgeFailureReason(t *testing.T) {
+	result := LLMPlanner{Bridge: failingBridge{}}.Plan("show files", nil)
+	if result.Reason != "agent: llm bridge failed" {
+		t.Fatalf("unexpected bridge failure: %q", result.Reason)
+	}
+}
+
+func TestResponseAddTraceStopsAtCapacity(t *testing.T) {
+	var response Response
+	for i := 0; i < MaxTraceEntries+2; i++ {
+		response.AddTrace("stage", "detail")
+	}
+	if response.TraceCount != MaxTraceEntries {
+		t.Fatalf("expected trace count %d, got %d", MaxTraceEntries, response.TraceCount)
+	}
+}
+
+func TestContextRememberRollsRecentItems(t *testing.T) {
+	var context Context
+	for i := 0; i < MaxRecentItems+1; i++ {
+		context.Remember("input", "result", IntentShowHelp)
+	}
+	if context.RecentCount != MaxRecentItems {
+		t.Fatalf("expected recent count %d, got %d", MaxRecentItems, context.RecentCount)
+	}
+	if context.LastIntent != IntentShowHelp {
+		t.Fatalf("unexpected last intent: %v", context.LastIntent)
+	}
+}
+
+func TestEnumStrings(t *testing.T) {
+	if PlannerModeDeterministic.String() != "deterministic" || PlannerModeLLM.String() != "llm" || PlannerMode(99).String() != "unknown" {
+		t.Fatalf("unexpected planner mode strings")
+	}
+	if IntentReadFile.String() != "read_file" || IntentWriteFile.String() != "write_file" || IntentDeleteFile.String() != "delete_file" || IntentKind(99).String() != "unknown" {
+		t.Fatalf("unexpected intent strings")
+	}
+	if ActionNone.String() != "none" || ActionDeleteFile.String() != "delete_file" || ActionKind(99).String() != "none" {
+		t.Fatalf("unexpected action strings")
+	}
+	if RiskSafe.String() != "safe" || RiskRisky.String() != "risky" {
+		t.Fatalf("unexpected risk strings")
+	}
+	if SafetyAllowed.String() != "allowed" || SafetyConfirmationRequired.String() != "confirmation_required" || SafetyRejected.String() != "rejected" {
+		t.Fatalf("unexpected safety strings")
+	}
+}
+
+type staticPlanner struct {
+	plan Plan
+}
+
+func (p staticPlanner) Plan(input string, context *Context) PlanningResult {
+	return successfulPlan(p.plan)
+}
+
+type failingPlanner struct {
+	reason string
+}
+
+func (p failingPlanner) Plan(input string, context *Context) PlanningResult {
+	return PlanningResult{OK: false, Reason: p.reason}
+}
+
+type fakeBridge struct {
+	plan Plan
+}
+
+func (b fakeBridge) Plan(input string, context *Context) PlanningResult {
+	return successfulPlan(b.plan)
+}
+
+type failingBridge struct {
+	reason string
+}
+
+func (b failingBridge) Plan(input string, context *Context) PlanningResult {
+	return PlanningResult{OK: false, Reason: b.reason}
+}
+
+func planWithAction(action Action) Plan {
+	var plan Plan
+	plan.ActionCount = 1
+	plan.Actions[0] = action
+	return plan
+}

--- a/agent/doc.go
+++ b/agent/doc.go
@@ -1,0 +1,8 @@
+// Package agent defines the v0.5.0 Minimum Working Agent runtime boundary.
+//
+// The package intentionally models agent execution as typed plans and actions,
+// not shell strings. A planner may be deterministic or backed by an external
+// LLM bridge, but the shared runtime always validates the returned plan, routes
+// risky work through a safety gate, and executes only known action kinds through
+// the constrained Executor interface.
+package agent

--- a/agent/executor.go
+++ b/agent/executor.go
@@ -1,0 +1,41 @@
+package agent
+
+type ActionHandler func(action Action, context *Context) ActionResult
+
+// AllowedActionExecutor is the constrained action surface for the agent
+// Shell or filesystem integration can wire only the handlers it wants to expose;
+// unsupported action kinds fail closed instead of falling through to a shell
+type AllowedActionExecutor struct {
+	ListFiles  ActionHandler
+	ReadFile   ActionHandler
+	WriteFile  ActionHandler
+	DeleteFile ActionHandler
+	StatFile   ActionHandler
+	ShowHelp   ActionHandler
+}
+
+func (e AllowedActionExecutor) Execute(action Action, context *Context) ActionResult {
+	switch action.Kind {
+	case ActionListFiles:
+		return callHandler(e.ListFiles, action, context)
+	case ActionReadFile:
+		return callHandler(e.ReadFile, action, context)
+	case ActionWriteFile:
+		return callHandler(e.WriteFile, action, context)
+	case ActionDeleteFile:
+		return callHandler(e.DeleteFile, action, context)
+	case ActionStatFile:
+		return callHandler(e.StatFile, action, context)
+	case ActionShowHelp:
+		return callHandler(e.ShowHelp, action, context)
+	default:
+		return ActionResult{OK: false, Message: "agent: unsupported action"}
+	}
+}
+
+func callHandler(handler ActionHandler, action Action, context *Context) ActionResult {
+	if handler == nil {
+		return ActionResult{OK: false, Message: "agent: action unavailable"}
+	}
+	return handler(action, context)
+}

--- a/agent/planner.go
+++ b/agent/planner.go
@@ -3,11 +3,11 @@ package agent
 type DeterministicPlanner struct{}
 
 func (DeterministicPlanner) Plan(input string, _ *Context) PlanningResult {
-	if contains(input, "ls") || contains(input, "files") || contains(input, "file") {
-		return successfulPlan(singleActionPlan(PlannerModeDeterministic, IntentListFiles, ActionListFiles, RiskSafe))
-	}
 	if contains(input, "help") || contains(input, "commands") {
 		return successfulPlan(singleActionPlan(PlannerModeDeterministic, IntentShowHelp, ActionShowHelp, RiskSafe))
+	}
+	if contains(input, "ls") || contains(input, "files") || contains(input, "file") {
+		return successfulPlan(singleActionPlan(PlannerModeDeterministic, IntentListFiles, ActionListFiles, RiskSafe))
 	}
 	return successfulPlan(singleActionPlan(PlannerModeDeterministic, IntentShowHelp, ActionShowHelp, RiskSafe))
 }

--- a/agent/planner.go
+++ b/agent/planner.go
@@ -1,0 +1,80 @@
+package agent
+
+type DeterministicPlanner struct{}
+
+func (DeterministicPlanner) Plan(input string, context *Context) PlanningResult {
+	if contains(input, "ls") || contains(input, "files") || contains(input, "file") {
+		return successfulPlan(singleActionPlan(PlannerModeDeterministic, IntentListFiles, ActionListFiles, RiskSafe))
+	}
+	if contains(input, "help") || contains(input, "commands") {
+		return successfulPlan(singleActionPlan(PlannerModeDeterministic, IntentShowHelp, ActionShowHelp, RiskSafe))
+	}
+	return successfulPlan(singleActionPlan(PlannerModeDeterministic, IntentShowHelp, ActionShowHelp, RiskSafe))
+}
+
+type BridgeClient interface {
+	Plan(input string, context *Context) PlanningResult
+}
+
+type LLMPlanner struct {
+	Bridge BridgeClient
+}
+
+func (p LLMPlanner) Plan(input string, context *Context) PlanningResult {
+	if p.Bridge == nil {
+		return PlanningResult{OK: false, Reason: "agent: llm bridge not configured"}
+	}
+
+	result := p.Bridge.Plan(input, context)
+	if !result.OK {
+		if result.Reason == "" {
+			result.Reason = "agent: llm bridge failed"
+		}
+		return result
+	}
+	result.Plan.Planner = PlannerModeLLM
+	return result
+}
+
+func singleActionPlan(mode PlannerMode, intent IntentKind, actionKind ActionKind, risk RiskLevel) Plan {
+	var plan Plan
+	plan.Planner = mode
+	plan.Intent = intent
+	plan.Confidence = 100
+	plan.ActionCount = 1
+	plan.Actions[0] = Action{Kind: actionKind, Risk: risk}
+	return plan
+}
+
+func successfulPlan(plan Plan) PlanningResult {
+	return PlanningResult{OK: true, Plan: plan}
+}
+
+func contains(text, token string) bool {
+	if len(token) == 0 {
+		return true
+	}
+	if len(token) > len(text) {
+		return false
+	}
+	for i := 0; i <= len(text)-len(token); i++ {
+		match := true
+		for j := 0; j < len(token); j++ {
+			if lowerASCII(text[i+j]) != lowerASCII(token[j]) {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+func lowerASCII(c byte) byte {
+	if c >= 'A' && c <= 'Z' {
+		return c - 'A' + 'a'
+	}
+	return c
+}

--- a/agent/planner.go
+++ b/agent/planner.go
@@ -2,7 +2,7 @@ package agent
 
 type DeterministicPlanner struct{}
 
-func (DeterministicPlanner) Plan(input string, context *Context) PlanningResult {
+func (DeterministicPlanner) Plan(input string, _ *Context) PlanningResult {
 	if contains(input, "ls") || contains(input, "files") || contains(input, "file") {
 		return successfulPlan(singleActionPlan(PlannerModeDeterministic, IntentListFiles, ActionListFiles, RiskSafe))
 	}
@@ -20,9 +20,11 @@ type LLMPlanner struct {
 	Bridge BridgeClient
 }
 
+const errLLMBridgeNotConfigured = "agent: llm bridge not configured"
+
 func (p LLMPlanner) Plan(input string, context *Context) PlanningResult {
 	if p.Bridge == nil {
-		return PlanningResult{OK: false, Reason: "agent: llm bridge not configured"}
+		return PlanningResult{OK: false, Reason: errLLMBridgeNotConfigured}
 	}
 
 	result := p.Bridge.Plan(input, context)

--- a/agent/runtime.go
+++ b/agent/runtime.go
@@ -1,0 +1,178 @@
+package agent
+
+type Planner interface {
+	Plan(input string, context *Context) PlanningResult
+}
+
+type Validator interface {
+	Validate(plan Plan) ValidationResult
+}
+
+type SafetyGate interface {
+	Evaluate(plan Plan, context *Context) SafetyDecision
+}
+
+type Executor interface {
+	Execute(action Action, context *Context) ActionResult
+}
+
+type Formatter interface {
+	Format(plan Plan, results [MaxActions]ActionResult, resultCount int, safety SafetyDecision) ActionResult
+}
+
+type Runtime struct {
+	Planner    Planner
+	Validator  Validator
+	SafetyGate SafetyGate
+	Executor   Executor
+	Formatter  Formatter
+}
+
+// Run executes the shared agent pipeline:
+// planner -> validator -> safety gate -> typed action executor -> formatter
+func (r Runtime) Run(input string, context *Context) Response {
+	var response Response
+	if r.Planner == nil {
+		response.Result = ActionResult{OK: false, Message: "agent: planner not configured"}
+		response.Safety = SafetyDecision{Status: SafetyRejected, Reason: "planner_missing"}
+		response.AddTrace("Planner", "missing")
+		return response
+	}
+
+	planning := r.Planner.Plan(input, context)
+	if !planning.OK {
+		reason := planning.Reason
+		if reason == "" {
+			reason = "agent: planner failed"
+		}
+		response.Result = ActionResult{OK: false, Message: reason}
+		response.Safety = SafetyDecision{Status: SafetyRejected, Reason: "planner_failed"}
+		response.AddTrace("Planner", reason)
+		return response
+	}
+
+	plan := planning.Plan
+	response.AddTrace("Planner", plan.Planner.String())
+	response.AddTrace("Intent", plan.Intent.String())
+
+	validator := r.Validator
+	if validator == nil {
+		validator = DefaultValidator{}
+	}
+	validation := validator.Validate(plan)
+	if !validation.OK {
+		response.Result = ActionResult{OK: false, Message: validation.Reason}
+		response.Safety = SafetyDecision{Status: SafetyRejected, Reason: "validation_failed"}
+		response.AddTrace("Validation", validation.Reason)
+		return response
+	}
+	response.AddTrace("Validation", "ok")
+
+	gate := r.SafetyGate
+	if gate == nil {
+		gate = DefaultSafetyGate{}
+	}
+	safety := gate.Evaluate(plan, context)
+	response.Safety = safety
+	response.AddTrace("Safety", safety.Status.String())
+	if safety.Status != SafetyAllowed {
+		response.Result = ActionResult{OK: false, Message: safety.Reason}
+		return response
+	}
+
+	if r.Executor == nil {
+		response.Result = ActionResult{OK: false, Message: "agent: executor not configured"}
+		response.AddTrace("Executor", "missing")
+		return response
+	}
+
+	var results [MaxActions]ActionResult
+	for i := 0; i < plan.ActionCount; i++ {
+		results[i] = r.Executor.Execute(plan.Actions[i], context)
+		if !results[i].OK {
+			response.AddTrace("Executor", "failed")
+			response.Result = results[i]
+			return response
+		}
+	}
+	response.AddTrace("Executor", "success")
+
+	formatter := r.Formatter
+	if formatter == nil {
+		formatter = DefaultFormatter{}
+	}
+	response.Result = formatter.Format(plan, results, plan.ActionCount, safety)
+	response.AddTrace("Formatter", "structured")
+	if context != nil {
+		context.Remember(input, response.Result.Message, plan.Intent)
+	}
+	return response
+}
+
+type DefaultValidator struct{}
+
+func (DefaultValidator) Validate(plan Plan) ValidationResult {
+	if plan.ActionCount <= 0 {
+		return ValidationResult{OK: false, Reason: "agent: plan has no actions"}
+	}
+	if plan.ActionCount > MaxActions {
+		return ValidationResult{OK: false, Reason: "agent: plan has too many actions"}
+	}
+	for i := 0; i < plan.ActionCount; i++ {
+		action := plan.Actions[i]
+		if !validActionKind(action.Kind) {
+			return ValidationResult{OK: false, Reason: "agent: plan contains unsupported action"}
+		}
+		if !validRiskLevel(action.Risk) {
+			return ValidationResult{OK: false, Reason: "agent: action risk is invalid"}
+		}
+		if action.TargetLen < 0 || action.TargetLen > MaxNameLen {
+			return ValidationResult{OK: false, Reason: "agent: action target is invalid"}
+		}
+		if action.DataLen < 0 || action.DataLen > MaxDataLen {
+			return ValidationResult{OK: false, Reason: "agent: action data is invalid"}
+		}
+	}
+	return ValidationResult{OK: true, Reason: "ok"}
+}
+
+func validActionKind(kind ActionKind) bool {
+	switch kind {
+	case ActionListFiles, ActionReadFile, ActionWriteFile, ActionDeleteFile, ActionStatFile, ActionShowHelp:
+		return true
+	default:
+		return false
+	}
+}
+
+func validRiskLevel(risk RiskLevel) bool {
+	switch risk {
+	case RiskSafe, RiskRisky:
+		return true
+	default:
+		return false
+	}
+}
+
+type DefaultSafetyGate struct{}
+
+func (DefaultSafetyGate) Evaluate(plan Plan, context *Context) SafetyDecision {
+	for i := 0; i < plan.ActionCount; i++ {
+		if plan.Actions[i].Risk == RiskRisky {
+			return SafetyDecision{Status: SafetyConfirmationRequired, Reason: "agent: confirmation required"}
+		}
+	}
+	return SafetyDecision{Status: SafetyAllowed, Reason: "ok"}
+}
+
+type DefaultFormatter struct{}
+
+func (DefaultFormatter) Format(plan Plan, results [MaxActions]ActionResult, resultCount int, safety SafetyDecision) ActionResult {
+	if resultCount <= 0 {
+		return ActionResult{OK: false, Message: "agent: no result"}
+	}
+	if resultCount == 1 {
+		return results[0]
+	}
+	return ActionResult{OK: true, Message: "agent: completed plan"}
+}

--- a/agent/runtime.go
+++ b/agent/runtime.go
@@ -156,7 +156,7 @@ func validRiskLevel(risk RiskLevel) bool {
 
 type DefaultSafetyGate struct{}
 
-func (DefaultSafetyGate) Evaluate(plan Plan, context *Context) SafetyDecision {
+func (DefaultSafetyGate) Evaluate(plan Plan, _ *Context) SafetyDecision {
 	for i := 0; i < plan.ActionCount; i++ {
 		if plan.Actions[i].Risk == RiskRisky {
 			return SafetyDecision{Status: SafetyConfirmationRequired, Reason: "agent: confirmation required"}
@@ -167,7 +167,7 @@ func (DefaultSafetyGate) Evaluate(plan Plan, context *Context) SafetyDecision {
 
 type DefaultFormatter struct{}
 
-func (DefaultFormatter) Format(plan Plan, results [MaxActions]ActionResult, resultCount int, safety SafetyDecision) ActionResult {
+func (DefaultFormatter) Format(_ Plan, results [MaxActions]ActionResult, resultCount int, _ SafetyDecision) ActionResult {
 	if resultCount <= 0 {
 		return ActionResult{OK: false, Message: "agent: no result"}
 	}

--- a/agent/types.go
+++ b/agent/types.go
@@ -1,0 +1,211 @@
+package agent
+
+const (
+	MaxActions      = 4
+	MaxTraceEntries = 8
+	MaxNameLen      = 16
+	MaxDataLen      = 128
+	MaxRecentItems  = 4
+)
+
+type PlannerMode uint8
+
+const (
+	PlannerModeDeterministic PlannerMode = iota
+	PlannerModeLLM
+)
+
+func (m PlannerMode) String() string {
+	switch m {
+	case PlannerModeDeterministic:
+		return "deterministic"
+	case PlannerModeLLM:
+		return "llm"
+	default:
+		return "unknown"
+	}
+}
+
+type IntentKind uint8
+
+const (
+	IntentUnknown IntentKind = iota
+	IntentListFiles
+	IntentReadFile
+	IntentWriteFile
+	IntentDeleteFile
+	IntentStatFile
+	IntentShowHelp
+)
+
+func (i IntentKind) String() string {
+	switch i {
+	case IntentListFiles:
+		return "list_files"
+	case IntentReadFile:
+		return "read_file"
+	case IntentWriteFile:
+		return "write_file"
+	case IntentDeleteFile:
+		return "delete_file"
+	case IntentStatFile:
+		return "stat_file"
+	case IntentShowHelp:
+		return "show_help"
+	default:
+		return "unknown"
+	}
+}
+
+type ActionKind uint8
+
+const (
+	ActionNone ActionKind = iota
+	ActionListFiles
+	ActionReadFile
+	ActionWriteFile
+	ActionDeleteFile
+	ActionStatFile
+	ActionShowHelp
+)
+
+func (k ActionKind) String() string {
+	switch k {
+	case ActionListFiles:
+		return "list_files"
+	case ActionReadFile:
+		return "read_file"
+	case ActionWriteFile:
+		return "write_file"
+	case ActionDeleteFile:
+		return "delete_file"
+	case ActionStatFile:
+		return "stat_file"
+	case ActionShowHelp:
+		return "show_help"
+	default:
+		return "none"
+	}
+}
+
+type RiskLevel uint8
+
+const (
+	RiskSafe RiskLevel = iota
+	RiskRisky
+)
+
+func (r RiskLevel) String() string {
+	switch r {
+	case RiskRisky:
+		return "risky"
+	default:
+		return "safe"
+	}
+}
+
+type SafetyStatus uint8
+
+const (
+	SafetyRejected SafetyStatus = iota
+	SafetyAllowed
+	SafetyConfirmationRequired
+)
+
+func (s SafetyStatus) String() string {
+	switch s {
+	case SafetyAllowed:
+		return "allowed"
+	case SafetyConfirmationRequired:
+		return "confirmation_required"
+	default:
+		return "rejected"
+	}
+}
+
+// Action is the only executable unit the agent runtime understands
+// There is deliberately no raw command field here: shell integration must map
+// these typed action kinds onto explicit internal APIs in a later layer
+type Action struct {
+	Kind      ActionKind
+	Risk      RiskLevel
+	Target    [MaxNameLen]byte
+	TargetLen int
+	Data      [MaxDataLen]byte
+	DataLen   int
+}
+
+type Plan struct {
+	Planner     PlannerMode
+	Intent      IntentKind
+	Confidence  uint8
+	Actions     [MaxActions]Action
+	ActionCount int
+}
+
+type PlanningResult struct {
+	OK     bool
+	Plan   Plan
+	Reason string
+}
+
+type ValidationResult struct {
+	OK     bool
+	Reason string
+}
+
+type SafetyDecision struct {
+	Status SafetyStatus
+	Reason string
+}
+
+type ActionResult struct {
+	OK      bool
+	Message string
+}
+
+type TraceEntry struct {
+	Stage  string
+	Detail string
+}
+
+type Response struct {
+	Trace      [MaxTraceEntries]TraceEntry
+	TraceCount int
+	Result     ActionResult
+	Safety     SafetyDecision
+}
+
+func (r *Response) AddTrace(stage, detail string) {
+	if r.TraceCount >= MaxTraceEntries {
+		return
+	}
+	r.Trace[r.TraceCount] = TraceEntry{Stage: stage, Detail: detail}
+	r.TraceCount++
+}
+
+type Context struct {
+	LastIntent    IntentKind
+	RecentInputs  [MaxRecentItems]string
+	RecentResults [MaxRecentItems]string
+	RecentCount   int
+}
+
+func (c *Context) Remember(input, result string, intent IntentKind) {
+	if c == nil {
+		return
+	}
+	c.LastIntent = intent
+	if c.RecentCount < MaxRecentItems {
+		c.RecentInputs[c.RecentCount] = input
+		c.RecentResults[c.RecentCount] = result
+		c.RecentCount++
+		return
+	}
+	for i := 1; i < MaxRecentItems; i++ {
+		c.RecentInputs[i-1] = c.RecentInputs[i]
+		c.RecentResults[i-1] = c.RecentResults[i]
+	}
+	c.RecentInputs[MaxRecentItems-1] = input
+	c.RecentResults[MaxRecentItems-1] = result
+}

--- a/agent/types.go
+++ b/agent/types.go
@@ -13,6 +13,12 @@ type PlannerMode uint8
 const (
 	PlannerModeDeterministic PlannerMode = iota
 	PlannerModeLLM
+
+	stringUnknown    = "unknown"
+	stringReadFile   = "read_file"
+	stringWriteFile  = "write_file"
+	stringDeleteFile = "delete_file"
+	stringNone       = "none"
 )
 
 func (m PlannerMode) String() string {
@@ -22,7 +28,7 @@ func (m PlannerMode) String() string {
 	case PlannerModeLLM:
 		return "llm"
 	default:
-		return "unknown"
+		return stringUnknown
 	}
 }
 
@@ -43,17 +49,17 @@ func (i IntentKind) String() string {
 	case IntentListFiles:
 		return "list_files"
 	case IntentReadFile:
-		return "read_file"
+		return stringReadFile
 	case IntentWriteFile:
-		return "write_file"
+		return stringWriteFile
 	case IntentDeleteFile:
-		return "delete_file"
+		return stringDeleteFile
 	case IntentStatFile:
 		return "stat_file"
 	case IntentShowHelp:
 		return "show_help"
 	default:
-		return "unknown"
+		return stringUnknown
 	}
 }
 
@@ -74,17 +80,17 @@ func (k ActionKind) String() string {
 	case ActionListFiles:
 		return "list_files"
 	case ActionReadFile:
-		return "read_file"
+		return stringReadFile
 	case ActionWriteFile:
-		return "write_file"
+		return stringWriteFile
 	case ActionDeleteFile:
-		return "delete_file"
+		return stringDeleteFile
 	case ActionStatFile:
 		return "stat_file"
 	case ActionShowHelp:
 		return "show_help"
 	default:
-		return "none"
+		return stringNone
 	}
 }
 

--- a/docs/v0.5.0/agent_runtime.md
+++ b/docs/v0.5.0/agent_runtime.md
@@ -1,0 +1,52 @@
+# v0.5.0 Agent Runtime Architecture
+
+Issue #151 defines the foundation for the v0.5.0 Minimum Working Agent. The
+runtime is intentionally split into small components so natural-language input
+never flows directly into shell execution.
+
+## Package Boundary
+
+The `agent` package owns the shared pipeline and data model:
+
+```txt
+Planner
+  -> Validator
+  -> Safety Gate
+  -> Executor
+  -> Formatter
+  -> Context update
+```
+
+The package exposes typed `Plan` and `Action` values. There is no raw shell
+command field in an action. Shell integration must map known action kinds such
+as `list_files`, `read_file`, or `delete_file` onto explicit internal APIs.
+
+## Components
+
+- `Planner`: converts user input and lightweight context into a typed plan.
+- `DeterministicPlanner`: local rule-based planner that is always available.
+- `LLMPlanner`: planner facade backed by a host-side `BridgeClient`.
+- `BridgeClient`: boundary for the external LLM bridge process.
+- `Validator`: rejects malformed plans and unsupported action kinds.
+- `SafetyGate`: allows safe actions and stops risky actions for confirmation.
+- `Executor`: constrained action surface; it executes typed actions only.
+- `Formatter`: turns action results into the structured agent response.
+- `Context`: records minimal recent inputs, outputs, and the last intent.
+
+## Security Model
+
+The LLM can propose plans, but it cannot execute commands. The runtime accepts
+only known `ActionKind` values, validates bounds on action fields, and fails
+closed when a handler is not wired. Risky actions such as deletion are marked as
+`confirmation_required` by the safety gate before any executor is called.
+
+The LLM planner does not silently fall back to deterministic mode. If the bridge
+is not configured or returns an error, planning fails and the runtime returns
+that error before validation, safety evaluation, or execution.
+
+## Initial Integration Direction
+
+The first shell-facing integration should wire a narrow `AllowedActionExecutor`
+to existing filesystem helpers. The deterministic planner can prove the flow in
+QEMU, while the LLM planner can later delegate planning to a host-side bridge
+that returns the same typed plan structure.

--- a/docs/v0.5.0/agentic_os.md
+++ b/docs/v0.5.0/agentic_os.md
@@ -136,6 +136,11 @@ The first step can be a minimal agent that proves the interaction model without 
 *   Maintain lightweight conversational context such as the current task, recent commands, and recent outputs.
 *   Return structured, human-readable responses instead of raw shell output whenever possible.
 
+The concrete v0.5.0 runtime boundary is documented in
+[`agent_runtime.md`](./agent_runtime.md). It defines the `Planner`,
+`Validator`, `Safety Gate`, `Executor`, `Context`, `Formatter`, and host-side
+`Bridge Client` responsibilities used by the initial implementation.
+
 This stage establishes the user experience of a conversational operating system while staying compatible with the primitive state of the current OS.
 
 ### v0.6.0: Better Context and Safer Execution

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,3 +14,5 @@ nav:
   - Syscall Entry And ABI: manual/03-kernel-core/syscall-entry-and-abi.md
   - User/Kernel Memory Isolation: manual/03-kernel-core/user-kernel-memory-isolation.md
   - Release Checklist: manual/03-kernel-core/release-checklist.md
+  - v0.5.0 Agentic OS: v0.5.0/agentic_os.md
+  - v0.5.0 Agent Runtime: v0.5.0/agent_runtime.md

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -16,6 +16,8 @@ const (
 	osName               = "DavOS"
 	maxDistanceThreshold = 3
 	osVersion            = "0.2.0"
+	commandHelp          = "help"
+	commandHistory       = "history"
 )
 
 var (
@@ -45,9 +47,9 @@ var (
 const maxHistory = 32
 
 var commandBuf = [...]string{
-	"help", "clear", "echo", "ticks", "uptime", "mem", "mmap",
+	commandHelp, "clear", "echo", "ticks", "uptime", "mem", "mmap",
 	"pfa", "alloc", "free", "ls", "write", "cat", "rm", "stat",
-	"version", "history", "run", "layout",
+	"version", commandHistory, "run", "layout",
 }
 
 func SetTickProvider(fn func() uint64)        { getTicks = fn }
@@ -148,7 +150,7 @@ func execute() {
 
 	cmdStart, cmdEnd := firstToken(start, end)
 
-	if matchLiteral(cmdStart, cmdEnd, "history") {
+	if matchLiteral(cmdStart, cmdEnd, commandHistory) {
 		// Print history
 		// We iterate from 0 to historyCount-1.
 		// To print chronologically (oldest first), we calculate the starting index
@@ -171,7 +173,7 @@ func execute() {
 		return
 	}
 
-	if matchLiteral(cmdStart, cmdEnd, "help") {
+	if matchLiteral(cmdStart, cmdEnd, commandHelp) {
 		terminal.Print("Commands: help, clear, echo, ticks, uptime, mem, mmap, pfa, alloc, free, ls, write, cat, rm, stat, version, history, run, disk, fatinit, fatformat, fatinfo, fatls, fatcreate, fatread, layout\n")
 		return
 	}


### PR DESCRIPTION
<!-- Reviewer's checklist lives in REVIEW.md. AGENTS.md covers expectations for AI-authored PRs. -->
## What
Added the architecture of the agentic runtime as provided in the related doc.

## Why
We are going to include in the OS a new Agentic mode capable of understand commands and execute them.
Closes #151 

## How to test
<!-- A concrete command (or sequence) the reviewer can run to verify the change. Example:
- `make test`
- `python3 scripts/test_boot.py --functional`
- Boot in QEMU and run `<command>` in the shell, expect `<output>`.
-->
Added unit tests, nothing to test.

## Pre-flight
- [X] `gofmt -l .` prints nothing
- [X] `go vet -tags testing -unsafeptr=false ./...` is clean
- [X] `make test` passes
- [X] `python3 scripts/test_boot.py` passes
- [X] PR is a single concern (no drive-by cleanups)

<!-- If AI was used substantially in this PR, leave one line below: "AI was used for assistance." -->
