### PR TITLE
test: cover keyboard scancode modifiers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,10 @@ docker-shell: docker-image
 # -----------------------
 # Unit tests and vet
 # -----------------------
+test:
+	mkdir -p $(BUILD_DIR)/.gocache
+	GOCACHE=$(CURDIR)/$(BUILD_DIR)/.gocache go test -tags testing $(TEST_PKGS)
+
 vet:
 	mkdir -p $(BUILD_DIR)/.gocache
 	GOCACHE=$(CURDIR)/$(BUILD_DIR)/.gocache go vet -tags testing -unsafeptr=false ./...

--- a/keyboard/io.go
+++ b/keyboard/io.go
@@ -1,0 +1,6 @@
+//go:build !testing
+
+package keyboard
+
+func inb(port uint16) byte
+func outb(port uint16, value byte)

--- a/keyboard/keyboard.go
+++ b/keyboard/keyboard.go
@@ -1,9 +1,4 @@
-//go:build !testing
-
 package keyboard
-
-func inb(port uint16) byte
-func outb(port uint16, value byte)
 
 const (
 	portData   uint16 = 0x60

--- a/keyboard/keyboard_test.go
+++ b/keyboard/keyboard_test.go
@@ -1,0 +1,143 @@
+//go:build testing
+
+package keyboard
+
+import "testing"
+
+type testLayout struct{}
+
+func (testLayout) GetKey(sc byte) (rune, bool) {
+	switch sc {
+	case 0x02:
+		return '1', true
+	case 0x1E:
+		return 'a', true
+	default:
+		return 0, false
+	}
+}
+
+func (testLayout) GetShiftDigitSymbol(r rune) (rune, bool) {
+	if r == '1' {
+		return '!', true
+	}
+	return 0, false
+}
+
+func resetKeyboardState() {
+	leftShiftDown = false
+	rightShiftDown = false
+	capsLockOn = false
+	SetLayout(testLayout{})
+}
+
+func TestTranslateScancodeLetterModifiers(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func()
+		want  rune
+	}{
+		{
+			name: "lowercase",
+			want: 'a',
+		},
+		{
+			name: "shift uppercase",
+			setup: func() {
+				translateScancode(scLeftShiftDown)
+			},
+			want: 'A',
+		},
+		{
+			name: "caps uppercase",
+			setup: func() {
+				translateScancode(scCapsLockDown)
+			},
+			want: 'A',
+		},
+		{
+			name: "shift caps lowercase",
+			setup: func() {
+				translateScancode(scLeftShiftDown)
+				translateScancode(scCapsLockDown)
+			},
+			want: 'a',
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetKeyboardState()
+			if tt.setup != nil {
+				tt.setup()
+			}
+
+			got, ok := translateScancode(0x1E)
+			if !ok {
+				t.Fatalf("translateScancode(0x1E) -> ok=false, want true")
+			}
+			if got != tt.want {
+				t.Fatalf("translateScancode(0x1E) = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTranslateScancodeShiftedDigitUsesLayoutSymbol(t *testing.T) {
+	resetKeyboardState()
+	translateScancode(scRightShiftDown)
+
+	got, ok := translateScancode(0x02)
+	if !ok {
+		t.Fatalf("translateScancode(0x02) -> ok=false, want true")
+	}
+	if got != '!' {
+		t.Fatalf("translateScancode(0x02) = %q, want %q", got, '!')
+	}
+}
+
+func TestTranslateScancodeShiftReleaseClearsModifier(t *testing.T) {
+	resetKeyboardState()
+
+	if r, ok := translateScancode(scLeftShiftDown); ok {
+		t.Fatalf("translateScancode(scLeftShiftDown) = (%q, true), want (_, false)", r)
+	}
+	got, ok := translateScancode(0x1E)
+	if !ok {
+		t.Fatalf("translateScancode(0x1E) with shift down -> ok=false, want true")
+	}
+	if got != 'A' {
+		t.Fatalf("translateScancode(0x1E) with shift down = %q, want %q", got, 'A')
+	}
+
+	if r, ok := translateScancode(scLeftShiftUp); ok {
+		t.Fatalf("translateScancode(scLeftShiftUp) = (%q, true), want (_, false)", r)
+	}
+	got, ok = translateScancode(0x1E)
+	if !ok {
+		t.Fatalf("translateScancode(0x1E) after shift release -> ok=false, want true")
+	}
+	if got != 'a' {
+		t.Fatalf("translateScancode(0x1E) after shift release = %q, want %q", got, 'a')
+	}
+}
+
+func TestTranslateScancodeIgnoresKeyReleasesAndUnmappedKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		sc   byte
+	}{
+		{name: "letter release", sc: 0x9E},
+		{name: "unmapped scancode", sc: 0x7F},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetKeyboardState()
+
+			if r, ok := translateScancode(tt.sc); ok {
+				t.Fatalf("translateScancode(0x%02X) = (%q, true), want (_, false)", tt.sc, r)
+			}
+		})
+	}
+}

--- a/keyboard/stubs.go
+++ b/keyboard/stubs.go
@@ -7,17 +7,11 @@ type Layout interface {
 	GetShiftDigitSymbol(r rune) (rune, bool)
 }
 
-func SetLayout(l Layout) {}
-
 func inb(port uint16) byte {
 	return 0
 }
 
 func outb(port uint16, value byte) {}
-
-func translateScancode(sc byte) (rune, bool) {
-	return 0, false
-}
 
 func IRQHandler() {}
 


### PR DESCRIPTION
## What

Adds tests for `translateScancode` modifier handling: lowercase letters, Shift uppercase, Caps Lock uppercase, Shift+Caps lowercase, shifted digit symbols, modifier release, key releases, and unmapped scancodes.

The pure scancode translation code is moved into a testable file, and `make test` now runs the existing discovered test packages.

## Why

Closes #129.

## How to test

Validated locally:
- `make test`
- `make vet`
- `gofmt -l .` printed nothing
- `git diff --check origin/main...HEAD`
- `git diff origin/main...HEAD | gitleaks stdin --no-banner --redact --timeout 30` (`no leaks found`)

Not run locally:
- `python3 scripts/test_boot.py` because `qemu-system-x86_64`, `x86_64-elf-gccgo`, `grub-mkrescue`, and `xorriso` are not installed in this environment.
- `golangci-lint run --timeout=5m` because `golangci-lint` is not installed locally.

## Pre-flight

- [x] `gofmt -l .` prints nothing
- [x] `go vet -tags testing -unsafeptr=false ./...` is clean via `make vet`
- [x] `make test` passes
- [ ] `python3 scripts/test_boot.py` passes
- [x] PR is a single concern (no drive-by cleanups)

AI was used for assistance.
