### PR TITLE
fix(shell): update osVersion to 0.0.5

### DIFF
--- a/scripts/test_boot.py
+++ b/scripts/test_boot.py
@@ -117,12 +117,12 @@ def run_functional_suite(iso_path, disk_img, log_file):
 
         test_cases = [
             ("help", ["Commands:", "agent"]),
-            ("version", ["DavOS 0.2.0 (64bit)"]),
+            ("version", ["DavOS 0.0.5 (64bit)"]),
             ("write notes hi", ["ok"]),
             ("agent show files", ["notes  size=2", "agent: files listed"]),
             ("agent help", ["Agent commands:", "agent delete <name> confirm"]),
             ("agent show history", ["agent: history listed"]),
-            ("agent show version", ["DavOS 0.2.0 (64bit)", "agent: version shown"]),
+            ("agent show version", ["DavOS 0.0.5 (64bit)", "agent: version shown"]),
             ("agent show ticks", ["agent: ticks shown"]),
             ("agent show memorymap", ["base=0x", "agent: memory map shown"]),
             ("agent read notes", ["hi", "agent: file read"]),

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -16,7 +16,7 @@ const (
 	maxLine              = 128
 	osName               = "DavOS"
 	maxDistanceThreshold = 3
-	osVersion            = "0.2.0"
+	osVersion            = "0.0.5"
 	commandHelp          = "help"
 	commandHistory       = "history"
 )

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -474,7 +474,7 @@ func TestExecuteAgentCommand(t *testing.T) {
 		{
 			name:  "show version",
 			input: "agent show version",
-			want:  "DavOS 0.2.0 (64bit)\nagent: version shown\n",
+			want:  "DavOS 0.0.5 (64bit)\nagent: version shown\n",
 		},
 		{
 			name:  "show ticks",


### PR DESCRIPTION
## What

Update `osVersion` in `shell/shell.go` from `0.2.0` to `0.0.5` and align the matching test expectation in `shell/shell_test.go`.

## Why

#169 requests the version printed by `agent show version` and the welcome banner to match the current project state. The fix updates the single source-of-truth constant (`osVersion` at `shell/shell.go:19`) and the one test that asserts the agent-mode output.

Closes #169

## How to test

- `gofmt -l .` prints nothing.
- `go vet -tags testing -unsafeptr=false ./...` is clean.
- `go test -tags testing ./shell/...` passes (the updated assertion runs as part of TestAgentShellExecute / agent show version case).
- After boot, `agent show version` prints `DavOS 0.0.5 (64bit)`.

## Pre-flight

- [x] `gofmt -l .` prints nothing
- [x] `go vet -tags testing -unsafeptr=false ./...` is clean
- [x] `make test` passes (`go test -tags testing ./...` green; QEMU integration suite not run locally)
- [ ] `python3 scripts/test_boot.py` passes (CI will run this)
- [x] PR is a single concern (no drive-by cleanups)

AI-assisted.
