### PR TITLE
Adding a fake LLM bridge

### DIFF
--- a/docs/v0.5.0/fake_llm_bridge.md
+++ b/docs/v0.5.0/fake_llm_bridge.md
@@ -1,0 +1,92 @@
+# v0.5.0 Fake Host LLM Bridge
+
+Issue #156 adds a deterministic host-side bridge for local testing. It lets the
+Agent pipeline exercise the LLM bridge contract without API keys, network
+access, or a real provider.
+
+The fake bridge is implemented by `scripts/fake_llm_bridge.py`. It reads one
+JSON Agent request from standard input and writes one structured JSON plan
+response to standard output.
+
+## Run It
+
+```sh
+printf '%s\n' '{
+  "input": "show me the files",
+  "context": {},
+  "allowedActions": [
+    "list_files",
+    "read_file",
+    "stat_file",
+    "delete_file",
+    "show_history",
+    "show_version",
+    "show_ticks",
+    "show_memory_map"
+  ]
+}' | python3 scripts/fake_llm_bridge.py
+```
+
+Example response:
+
+```json
+{
+  "action": "list_files",
+  "args": [],
+  "explanation": "Matched request to list files.",
+  "intent": "list_files",
+  "risk": "safe"
+}
+```
+
+## Mappings
+
+The fake bridge recognizes a small deterministic phrase set:
+
+```txt
+show me the files -> list_files
+show files        -> list_files
+list files        -> list_files
+read notes        -> read_file notes
+show notes        -> read_file notes
+stat notes        -> stat_file notes
+delete notes      -> delete_file notes
+remove notes      -> delete_file notes
+show history      -> show_history
+show version      -> show_version
+show ticks        -> show_ticks
+show memory map   -> show_memory_map
+show memorymap    -> show_memory_map
+```
+
+`delete_file` responses are marked `risky`. All other built-in fake responses
+are marked `safe`.
+
+## Allow List Behavior
+
+The bridge respects the request's `allowedActions` field. If a request maps to
+an action that is not allowed, the fake bridge returns:
+
+```json
+{
+  "intent": "unknown",
+  "action": "unknown",
+  "args": [],
+  "risk": "safe",
+  "explanation": "No allowed action matched the request."
+}
+```
+
+`unknown` is non-executable and exists only as a safe fallback plan.
+
+## Local Testing
+
+Run the bridge tests with:
+
+```sh
+python3 scripts/test_fake_llm_bridge.py
+```
+
+The script is host-side only. It is suitable for local harnesses and QEMU demos
+that can pass the protocol JSON over stdin/stdout, serial, debug console, or a
+future transport adapter. It does not add any kernel dependency on Python.

--- a/docs/v0.5.0/llm_bridge_protocol.md
+++ b/docs/v0.5.0/llm_bridge_protocol.md
@@ -145,3 +145,8 @@ must not be executed and must not be translated into shell input.
 The bridge is a planner only. It cannot execute, request arbitrary execution, or
 expand the action surface. The runtime validates the returned typed plan, runs
 the safety gate, and dispatches only through `AllowedActionExecutor`.
+
+## Fake Bridge
+
+For local testing without an LLM provider, use the deterministic fake bridge
+documented in [`fake_llm_bridge.md`](./fake_llm_bridge.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,3 +17,4 @@ nav:
   - v0.5.0 Agentic OS: v0.5.0/agentic_os.md
   - v0.5.0 Agent Runtime: v0.5.0/agent_runtime.md
   - v0.5.0 LLM Bridge Protocol: v0.5.0/llm_bridge_protocol.md
+  - v0.5.0 Fake LLM Bridge: v0.5.0/fake_llm_bridge.md

--- a/scripts/fake_llm_bridge.py
+++ b/scripts/fake_llm_bridge.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Deterministic host-side Agent bridge for local testing.
+
+The fake bridge reads one JSON request from stdin and writes one JSON response to
+stdout. It follows docs/v0.5.0/llm_bridge_protocol.md and does not call any
+external provider.
+"""
+
+import json
+import sys
+
+
+MAX_ARG_LEN = 16
+RAW_EXECUTION_FIELDS = {"command", "shell", "argv", "script", "exec"}
+
+
+def main():
+    response = plan_from_stdin(sys.stdin.read())
+    json.dump(response, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+
+
+def plan_from_stdin(text):
+    try:
+        request = json.loads(text)
+    except json.JSONDecodeError:
+        return unknown_response("Invalid JSON request.")
+
+    if not isinstance(request, dict):
+        return unknown_response("Request must be a JSON object.")
+    return plan_for_request(request)
+
+
+def plan_for_request(request):
+    if contains_raw_execution_field(request):
+        return unknown_response("Request contains raw execution fields.")
+
+    input_text = request.get("input", "")
+    if not isinstance(input_text, str):
+        return unknown_response("Request input must be a string.")
+
+    allowed = request.get("allowedActions", [])
+    if not isinstance(allowed, list):
+        return unknown_response("allowedActions must be a list.")
+    allowed_actions = {action for action in allowed if isinstance(action, str)}
+
+    intent, action, args, risk, explanation = map_input(input_text)
+    if action == "unknown" or action not in allowed_actions:
+        return unknown_response("No allowed action matched the request.")
+
+    return response(intent, action, args, risk, explanation)
+
+
+def contains_raw_execution_field(value):
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if key in RAW_EXECUTION_FIELDS:
+                return True
+            if contains_raw_execution_field(nested):
+                return True
+    elif isinstance(value, list):
+        for nested in value:
+            if contains_raw_execution_field(nested):
+                return True
+    return False
+
+
+def map_input(input_text):
+    text = lower_ascii(input_text)
+
+    if contains(text, "memorymap") or (contains(text, "memory") and contains(text, "map")):
+        return (
+            "show_memory_map",
+            "show_memory_map",
+            [],
+            "safe",
+            "Matched request to show the memory map.",
+        )
+    if contains(text, "version"):
+        return "show_version", "show_version", [], "safe", "Matched request to show the OS version."
+    if contains(text, "ticks"):
+        return "show_ticks", "show_ticks", [], "safe", "Matched request to show PIT ticks."
+    if contains(text, "history"):
+        return "show_history", "show_history", [], "safe", "Matched request to show Agent history."
+    if contains(text, "files") or contains(text, "file list") or contains(text, "list files") or contains(text, "ls"):
+        return "list_files", "list_files", [], "safe", "Matched request to list files."
+
+    if contains(text, "delete") or contains(text, "remove"):
+        target = last_token(text)
+        if target:
+            return (
+                "delete_file",
+                "delete_file",
+                [target],
+                "risky",
+                "Matched delete request for file " + target + ".",
+            )
+    if contains(text, "read") or contains(text, "cat"):
+        target = last_token(text)
+        if target:
+            return "read_file", "read_file", [target], "safe", "Matched read request for file " + target + "."
+    if contains(text, "stat") or contains(text, "status"):
+        target = last_token(text)
+        if target:
+            return "stat_file", "stat_file", [target], "safe", "Matched stat request for file " + target + "."
+    if contains(text, "show"):
+        target = last_token(text)
+        if target and target != "show":
+            return "read_file", "read_file", [target], "safe", "Matched show request for file " + target + "."
+
+    return "unknown", "unknown", [], "safe", "No supported fake bridge mapping matched the request."
+
+
+def unknown_response(explanation):
+    return response("unknown", "unknown", [], "safe", explanation)
+
+
+def response(intent, action, args, risk, explanation):
+    clean_args = []
+    for arg in args:
+        clean_args.append(arg[:MAX_ARG_LEN])
+
+    return {
+        "intent": intent,
+        "action": action,
+        "args": clean_args,
+        "risk": risk,
+        "explanation": explanation,
+    }
+
+
+def lower_ascii(text):
+    result = []
+    for char in text:
+        if "A" <= char <= "Z":
+            result.append(chr(ord(char) + 32))
+        else:
+            result.append(char)
+    return "".join(result)
+
+
+def contains(text, token):
+    return token in text
+
+
+def last_token(text):
+    tokens = [token for token in text.split() if token]
+    if not tokens:
+        return ""
+    token = tokens[-1]
+    if token in {"read", "cat", "delete", "remove", "stat", "status", "show"}:
+        return ""
+    return token
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_fake_llm_bridge.py
+++ b/scripts/test_fake_llm_bridge.py
@@ -1,0 +1,111 @@
+import importlib.util
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BRIDGE_PATH = ROOT / "scripts" / "fake_llm_bridge.py"
+
+
+spec = importlib.util.spec_from_file_location("fake_llm_bridge", BRIDGE_PATH)
+fake_llm_bridge = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(fake_llm_bridge)
+
+
+DEFAULT_ALLOWED = [
+    "list_files",
+    "read_file",
+    "stat_file",
+    "delete_file",
+    "show_history",
+    "show_version",
+    "show_ticks",
+    "show_memory_map",
+]
+
+
+class FakeLLMBridgeTest(unittest.TestCase):
+    def plan(self, input_text, allowed=None):
+        return fake_llm_bridge.plan_for_request(
+            {
+                "input": input_text,
+                "context": {
+                    "lastIntent": "read_file",
+                    "lastAction": "read_file",
+                    "lastSummary": "Read file notes",
+                    "requestCount": 3,
+                },
+                "allowedActions": DEFAULT_ALLOWED if allowed is None else allowed,
+            }
+        )
+
+    def test_cli_reads_agent_request_and_writes_structured_json(self):
+        request = {
+            "input": "show me the files",
+            "context": {},
+            "allowedActions": DEFAULT_ALLOWED,
+        }
+
+        result = subprocess.run(
+            [sys.executable, str(BRIDGE_PATH)],
+            input=json.dumps(request),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True,
+        )
+
+        response = json.loads(result.stdout)
+        self.assertEqual(response["intent"], "list_files")
+        self.assertEqual(response["action"], "list_files")
+        self.assertEqual(response["args"], [])
+        self.assertEqual(response["risk"], "safe")
+
+    def test_maps_read_request_with_target_arg(self):
+        response = self.plan("read notes")
+
+        self.assertEqual(response["intent"], "read_file")
+        self.assertEqual(response["action"], "read_file")
+        self.assertEqual(response["args"], ["notes"])
+        self.assertEqual(response["risk"], "safe")
+
+    def test_maps_delete_request_as_risky(self):
+        response = self.plan("delete notes")
+
+        self.assertEqual(response["intent"], "delete_file")
+        self.assertEqual(response["action"], "delete_file")
+        self.assertEqual(response["args"], ["notes"])
+        self.assertEqual(response["risk"], "risky")
+
+    def test_action_not_in_allow_list_returns_unknown(self):
+        response = self.plan("delete notes", allowed=["list_files", "read_file"])
+
+        self.assertEqual(response["intent"], "unknown")
+        self.assertEqual(response["action"], "unknown")
+        self.assertEqual(response["args"], [])
+        self.assertEqual(response["risk"], "safe")
+
+    def test_response_does_not_expose_raw_execution_fields(self):
+        response = self.plan("show version")
+
+        forbidden = {"command", "shell", "argv", "script", "exec"}
+        self.assertTrue(forbidden.isdisjoint(response.keys()))
+
+    def test_rejects_request_with_raw_execution_fields_safely(self):
+        response = fake_llm_bridge.plan_for_request(
+            {
+                "input": "show me the files",
+                "context": {"shell": "rm notes"},
+                "allowedActions": DEFAULT_ALLOWED,
+            }
+        )
+
+        self.assertEqual(response["intent"], "unknown")
+        self.assertEqual(response["action"], "unknown")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Reviewer's checklist lives in REVIEW.md. AGENTS.md covers expectations for AI-authored PRs. -->

## What

<!-- One or two lines: what does this change? -->

## Why

<!-- One or two lines: why does it need to change? Link to the issue if there is one. -->

Closes #156 

## How to test

<!-- A concrete command (or sequence) the reviewer can run to verify the change. Example:
- `make test`
- `python3 scripts/test_boot.py --functional`
- Boot in QEMU and run `<command>` in the shell, expect `<output>`.
-->

## Pre-flight

- [ ] `gofmt -l .` prints nothing
- [ ] `go vet -tags testing -unsafeptr=false ./...` is clean
- [ ] `make test` passes
- [ ] `python3 scripts/test_boot.py` passes
- [ ] PR is a single concern (no drive-by cleanups)

<!-- If AI was used substantially in this PR, leave one line below: "AI was used for assistance." -->
