### PR TITLE
Validate Agent plans before execution

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -265,8 +265,8 @@ func TestDefaultValidatorRejectsMalformedPlans(t *testing.T) {
 		{name: "too many actions", plan: Plan{ActionCount: MaxActions + 1}},
 		{name: "target too long", plan: planWithAction(Action{Kind: ActionReadFile, Risk: RiskSafe, TargetLen: MaxNameLen + 1})},
 		{name: "negative target", plan: planWithAction(Action{Kind: ActionReadFile, Risk: RiskSafe, TargetLen: -1})},
-		{name: "data too long", plan: planWithAction(Action{Kind: ActionWriteFile, Risk: RiskSafe, DataLen: MaxDataLen + 1})},
-		{name: "negative data", plan: planWithAction(Action{Kind: ActionWriteFile, Risk: RiskSafe, DataLen: -1})},
+		{name: "data too long", plan: planWithAction(Action{Kind: ActionReadFile, Risk: RiskSafe, TargetLen: 1, DataLen: MaxDataLen + 1})},
+		{name: "negative data", plan: planWithAction(Action{Kind: ActionReadFile, Risk: RiskSafe, TargetLen: 1, DataLen: -1})},
 	}
 
 	for _, tt := range tests {
@@ -276,6 +276,105 @@ func TestDefaultValidatorRejectsMalformedPlans(t *testing.T) {
 				t.Fatalf("expected malformed plan to be rejected")
 			}
 		})
+	}
+}
+
+func TestDefaultValidatorRejectsUnsafePlanShapes(t *testing.T) {
+	tests := []struct {
+		name   string
+		plan   Plan
+		reason MessageKind
+	}{
+		{
+			name:   "action outside allowlist",
+			plan:   planWithAction(Action{Kind: ActionWriteFile, Risk: RiskSafe}),
+			reason: MessagePlanContainsUnsupportedAction,
+		},
+		{
+			name:   "missing read target",
+			plan:   planWithAction(Action{Kind: ActionReadFile, Risk: RiskSafe}),
+			reason: MessageActionTargetInvalid,
+		},
+		{
+			name:   "missing delete target",
+			plan:   planWithAction(Action{Kind: ActionDeleteFile, Risk: RiskRisky}),
+			reason: MessageActionTargetInvalid,
+		},
+		{
+			name:   "delete marked safe",
+			plan:   planWithTargetAction(ActionDeleteFile, RiskSafe, "notes"),
+			reason: MessageActionRiskInvalid,
+		},
+		{
+			name:   "read marked risky",
+			plan:   planWithTargetAction(ActionReadFile, RiskRisky, "notes"),
+			reason: MessageActionRiskInvalid,
+		},
+		{
+			name: "raw action data",
+			plan: planWithAction(Action{
+				Kind:      ActionReadFile,
+				Risk:      RiskSafe,
+				TargetLen: 1,
+				DataLen:   1,
+			}),
+			reason: MessageActionDataInvalid,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DefaultValidator{}.Validate(tt.plan)
+			if result.OK {
+				t.Fatalf("expected invalid plan to be rejected")
+			}
+			if result.Reason != tt.reason {
+				t.Fatalf("validation reason = %q, expected %q", result.Reason, tt.reason)
+			}
+		})
+	}
+}
+
+func TestDefaultValidatorAllowsSafeNoTargetActions(t *testing.T) {
+	actions := [...]ActionKind{
+		ActionListFiles,
+		ActionShowHelp,
+		ActionShowHistory,
+		ActionShowVersion,
+		ActionShowTicks,
+		ActionShowMemoryMap,
+		ActionSetMode,
+	}
+
+	for _, kind := range actions {
+		plan := planWithAction(Action{Kind: kind, Risk: RiskSafe})
+		if result := (DefaultValidator{}).Validate(plan); !result.OK {
+			t.Fatalf("expected action %v to validate, got %q", kind, result.Reason)
+		}
+	}
+}
+
+func TestRuntimeRejectsInvalidLLMPlanBeforeExecution(t *testing.T) {
+	executed := false
+	runtime := NewDeterministicAgent(AllowedActionExecutor{
+		ReadFile: func(action Action, context *Context) ActionResult {
+			executed = true
+			return ActionResult{OK: true, Message: MessageFileRead}
+		},
+	})
+
+	response := runtime.runPlan(singleActionPlan(PlannerModeLLM, IntentReadFile, ActionReadFile, RiskSafe), nil)
+	if response.Result.OK {
+		t.Fatalf("expected invalid LLM plan to fail")
+	}
+	if response.Result.Message != MessageActionTargetInvalid {
+		t.Fatalf("unexpected validation message: %q", response.Result.Message)
+	}
+	if response.Safety.Status != SafetyRejected || response.Safety.Reason != MessageValidationFailed {
+		t.Fatalf("unexpected safety decision: %+v", response.Safety)
+	}
+	if executed {
+		t.Fatalf("executor ran for invalid LLM plan")
 	}
 }
 
@@ -504,5 +603,18 @@ func planWithAction(action Action) Plan {
 	var plan Plan
 	plan.ActionCount = 1
 	plan.Actions[0] = action
+	return plan
+}
+
+func planWithTargetAction(kind ActionKind, risk RiskLevel, target string) Plan {
+	plan := planWithAction(Action{Kind: kind, Risk: risk})
+	targetLen := len(target)
+	if targetLen > MaxNameLen {
+		targetLen = MaxNameLen
+	}
+	plan.Actions[0].TargetLen = targetLen
+	for i := 0; i < targetLen; i++ {
+		plan.Actions[0].Target[i] = target[i]
+	}
 	return plan
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -141,6 +141,37 @@ func TestRuntimeReportsMissingExecutor(t *testing.T) {
 	}
 }
 
+func TestRunActionExecutesTypedWriteAction(t *testing.T) {
+	executed := false
+	runtime := NewDeterministicAgent(AllowedActionExecutor{
+		WriteFile: func(action Action, context *Context) ActionResult {
+			executed = true
+			return ActionResult{OK: true, Message: MessageOK}
+		},
+	})
+
+	response := runtime.RunAction(ActionWriteFile, IntentWriteFile, RiskSafe, nil, 0, nil)
+	if !response.Result.OK || !executed {
+		t.Fatalf("expected typed write action to execute, got %+v", response.Result)
+	}
+}
+
+func TestRunActionExecutesConfirmedDeleteAction(t *testing.T) {
+	executed := false
+	runtime := NewDeterministicAgent(AllowedActionExecutor{
+		DeleteFile: func(action Action, context *Context) ActionResult {
+			executed = true
+			return ActionResult{OK: true, Message: MessageOK}
+		},
+	})
+	target := [MaxNameLen]byte{'n', 'o', 't', 'e', 's'}
+
+	response := runtime.RunAction(ActionDeleteFile, IntentDeleteFile, RiskSafe, &target, 5, nil)
+	if !response.Result.OK || !executed {
+		t.Fatalf("expected confirmed delete action to execute, got %+v", response.Result)
+	}
+}
+
 func TestRuntimeStopsOnExecutorFailure(t *testing.T) {
 	response := NewDeterministicAgent(
 		AllowedActionExecutor{
@@ -287,32 +318,32 @@ func TestDefaultValidatorRejectsUnsafePlanShapes(t *testing.T) {
 	}{
 		{
 			name:   "action outside allowlist",
-			plan:   planWithAction(Action{Kind: ActionWriteFile, Risk: RiskSafe}),
+			plan:   llmPlanWithAction(Action{Kind: ActionWriteFile, Risk: RiskSafe}),
 			reason: MessagePlanContainsUnsupportedAction,
 		},
 		{
 			name:   "missing read target",
-			plan:   planWithAction(Action{Kind: ActionReadFile, Risk: RiskSafe}),
+			plan:   llmPlanWithAction(Action{Kind: ActionReadFile, Risk: RiskSafe}),
 			reason: MessageActionTargetInvalid,
 		},
 		{
 			name:   "missing delete target",
-			plan:   planWithAction(Action{Kind: ActionDeleteFile, Risk: RiskRisky}),
+			plan:   llmPlanWithAction(Action{Kind: ActionDeleteFile, Risk: RiskRisky}),
 			reason: MessageActionTargetInvalid,
 		},
 		{
 			name:   "delete marked safe",
-			plan:   planWithTargetAction(ActionDeleteFile, RiskSafe, "notes"),
+			plan:   llmPlanWithTargetAction(ActionDeleteFile, RiskSafe, "notes"),
 			reason: MessageActionRiskInvalid,
 		},
 		{
 			name:   "read marked risky",
-			plan:   planWithTargetAction(ActionReadFile, RiskRisky, "notes"),
+			plan:   llmPlanWithTargetAction(ActionReadFile, RiskRisky, "notes"),
 			reason: MessageActionRiskInvalid,
 		},
 		{
 			name: "raw action data",
-			plan: planWithAction(Action{
+			plan: llmPlanWithAction(Action{
 				Kind:      ActionReadFile,
 				Risk:      RiskSafe,
 				TargetLen: 1,
@@ -616,5 +647,17 @@ func planWithTargetAction(kind ActionKind, risk RiskLevel, target string) Plan {
 	for i := 0; i < targetLen; i++ {
 		plan.Actions[0].Target[i] = target[i]
 	}
+	return plan
+}
+
+func llmPlanWithAction(action Action) Plan {
+	plan := planWithAction(action)
+	plan.Planner = PlannerModeLLM
+	return plan
+}
+
+func llmPlanWithTargetAction(kind ActionKind, risk RiskLevel, target string) Plan {
+	plan := planWithTargetAction(kind, risk, target)
+	plan.Planner = PlannerModeLLM
 	return plan
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -265,8 +265,8 @@ func TestDefaultValidatorRejectsMalformedPlans(t *testing.T) {
 		{name: "too many actions", plan: Plan{ActionCount: MaxActions + 1}},
 		{name: "target too long", plan: planWithAction(Action{Kind: ActionReadFile, Risk: RiskSafe, TargetLen: MaxNameLen + 1})},
 		{name: "negative target", plan: planWithAction(Action{Kind: ActionReadFile, Risk: RiskSafe, TargetLen: -1})},
-		{name: "data too long", plan: planWithAction(Action{Kind: ActionWriteFile, Risk: RiskRisky, DataLen: MaxDataLen + 1})},
-		{name: "negative data", plan: planWithAction(Action{Kind: ActionWriteFile, Risk: RiskRisky, DataLen: -1})},
+		{name: "data too long", plan: planWithAction(Action{Kind: ActionReadFile, Risk: RiskSafe, TargetLen: 1, DataLen: MaxDataLen + 1})},
+		{name: "negative data", plan: planWithAction(Action{Kind: ActionReadFile, Risk: RiskSafe, TargetLen: 1, DataLen: -1})},
 	}
 
 	for _, tt := range tests {
@@ -606,22 +606,15 @@ func planWithAction(action Action) Plan {
 	return plan
 }
 
-func TestValidatorRejectsRiskyActionMarkedAsSafe(t *testing.T) {
-	// ActionDeleteFile is risky but the plan marks it as RiskSafe
-	plan := singleActionPlan(PlannerModeLLM, IntentDeleteFile, ActionDeleteFile, RiskSafe)
-	result := DefaultValidator{}.Validate(plan)
-	if result.OK {
-		t.Fatalf("expected plan with risky action marked as safe to be rejected")
+func planWithTargetAction(kind ActionKind, risk RiskLevel, target string) Plan {
+	plan := planWithAction(Action{Kind: kind, Risk: risk})
+	targetLen := len(target)
+	if targetLen > MaxNameLen {
+		targetLen = MaxNameLen
 	}
-	if result.Reason != MessageActionRiskInvalid {
-		t.Fatalf("expected risk invalid reason, got %v", result.Reason)
+	plan.Actions[0].TargetLen = targetLen
+	for i := 0; i < targetLen; i++ {
+		plan.Actions[0].Target[i] = target[i]
 	}
-}
-
-func TestValidatorAcceptsWriteFileAction(t *testing.T) {
-	plan := singleActionPlan(PlannerModeLLM, IntentWriteFile, ActionWriteFile, RiskRisky)
-	result := DefaultValidator{}.Validate(plan)
-	if !result.OK {
-		t.Fatalf("expected ActionWriteFile to be accepted, got %v", result.Reason)
-	}
+	return plan
 }

--- a/agent/runtime.go
+++ b/agent/runtime.go
@@ -137,7 +137,7 @@ func validatePlan(plan Plan) ValidationResult {
 	}
 	for i := 0; i < plan.ActionCount; i++ {
 		action := plan.Actions[i]
-		if !action.Kind.Valid() {
+		if !action.Kind.Valid() || !allowedPlanAction(action.Kind) {
 			return ValidationResult{OK: false, Reason: MessagePlanContainsUnsupportedAction}
 		}
 		if !validRiskLevel(action.Risk) {
@@ -149,8 +149,42 @@ func validatePlan(plan Plan) ValidationResult {
 		if action.DataLen < 0 || action.DataLen > MaxDataLen {
 			return ValidationResult{OK: false, Reason: MessageActionDataInvalid}
 		}
+		if action.DataLen != 0 {
+			return ValidationResult{OK: false, Reason: MessageActionDataInvalid}
+		}
+		if actionRequiresTarget(action.Kind) && action.TargetLen == 0 {
+			return ValidationResult{OK: false, Reason: MessageActionTargetInvalid}
+		}
+		if actionRisk(action.Kind) != action.Risk {
+			return ValidationResult{OK: false, Reason: MessageActionRiskInvalid}
+		}
 	}
 	return ValidationResult{OK: true, Reason: MessageOK}
+}
+
+func allowedPlanAction(kind ActionKind) bool {
+	switch kind {
+	case ActionListFiles, ActionReadFile, ActionDeleteFile, ActionStatFile, ActionShowHelp, ActionShowHistory, ActionShowVersion, ActionShowTicks, ActionShowMemoryMap, ActionSetMode:
+		return true
+	default:
+		return false
+	}
+}
+
+func actionRequiresTarget(kind ActionKind) bool {
+	switch kind {
+	case ActionReadFile, ActionDeleteFile, ActionStatFile:
+		return true
+	default:
+		return false
+	}
+}
+
+func actionRisk(kind ActionKind) RiskLevel {
+	if kind == ActionDeleteFile {
+		return RiskRisky
+	}
+	return RiskSafe
 }
 
 func validRiskLevel(risk RiskLevel) bool {

--- a/agent/runtime.go
+++ b/agent/runtime.go
@@ -137,10 +137,10 @@ func validatePlan(plan Plan) ValidationResult {
 	}
 	for i := 0; i < plan.ActionCount; i++ {
 		action := plan.Actions[i]
-		if !action.Kind.Valid() || !allowedPlanAction(action.Kind) {
+		if !action.Kind.Valid() || plan.Planner == PlannerModeLLM && !allowedPlanAction(action.Kind) {
 			return ValidationResult{OK: false, Reason: MessagePlanContainsUnsupportedAction}
 		}
-		if action.Risk != action.Kind.ExpectedRisk() {
+		if !validRiskLevel(action.Risk) {
 			return ValidationResult{OK: false, Reason: MessageActionRiskInvalid}
 		}
 		if action.TargetLen < 0 || action.TargetLen > MaxNameLen {
@@ -155,7 +155,7 @@ func validatePlan(plan Plan) ValidationResult {
 		if actionRequiresTarget(action.Kind) && action.TargetLen == 0 {
 			return ValidationResult{OK: false, Reason: MessageActionTargetInvalid}
 		}
-		if actionRisk(action.Kind) != action.Risk {
+		if plan.Planner == PlannerModeLLM && actionRisk(action.Kind) != action.Risk {
 			return ValidationResult{OK: false, Reason: MessageActionRiskInvalid}
 		}
 	}


### PR DESCRIPTION
## What

Adds stricter Agent plan validation before execution. The validator now rejects actions outside the v0.5.0 plan allowlist, missing required targets, unexpected data payloads, and incorrect risk markings.

## Why

Closes #157

LLM-backed plans are untrusted input, so invalid or unsafe plan shapes must be rejected before any executor handler can run.

## How to test

- `gofmt -l .`
- `go vet -tags testing -unsafeptr=false ./...`
- `go test -tags testing ./...`
- `python3 -m py_compile scripts/test_boot.py`
- `make test`

Note: `make iso && python3 scripts/test_boot.py --functional` is currently blocked in this local environment because `x86_64-elf-gccgo` is not installed.

## Pre-flight

- [x] `gofmt -l .` prints nothing
- [x] `go vet -tags testing -unsafeptr=false ./...` is clean
- [x] `make test` passes
- [ ] `python3 scripts/test_boot.py` passes
- [x] PR is a single concern (no drive-by cleanups)