### PR TITLE
Add lightweight Agent session context

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -178,10 +178,16 @@ func TestRuntimeExecutesConfirmedDeleteAction(t *testing.T) {
 	if response.Safety.Status != SafetyConfirmationRequired || executed {
 		t.Fatalf("expected delete to wait for confirmation")
 	}
+	if context.CurrentTask != ActionDeleteFile || context.LastResultSummary != MessageConfirmationRequired {
+		t.Fatalf("pending context was not recorded: %+v", context)
+	}
 
 	response = runtime.ConfirmAction(true, &context)
 	if !response.Result.OK || !executed {
 		t.Fatalf("expected confirmed delete action to execute, got %+v", response.Result)
+	}
+	if context.CurrentTask != ActionNone || context.LastResultSummary != MessageOK {
+		t.Fatalf("confirmed context was not completed: %+v", context)
 	}
 }
 
@@ -246,19 +252,23 @@ func TestLLMPlanUsesSameConfirmationGate(t *testing.T) {
 }
 
 func TestRuntimeStopsOnExecutorFailure(t *testing.T) {
+	var context Context
 	response := NewDeterministicAgent(
 		AllowedActionExecutor{
 			ReadFile: func(action Action, context *Context) ActionResult {
 				return ActionResult{OK: false, Message: MessageReadFailed}
 			},
 		},
-	).Run("read notes", nil)
+	).Run("read notes", &context)
 
 	if response.Result.OK {
 		t.Fatalf("expected executor failure")
 	}
 	if response.Result.Message != MessageReadFailed {
 		t.Fatalf("unexpected executor failure: %q", response.Result.Message)
+	}
+	if context.LastAction != ActionReadFile || context.LastResultSummary != MessageReadFailed || context.RequestCount != 1 {
+		t.Fatalf("executor failure was not recorded in context: %+v", context)
 	}
 }
 
@@ -662,6 +672,72 @@ func TestContextRememberRollsRecentItems(t *testing.T) {
 	}
 }
 
+func TestRuntimeUpdatesSessionContext(t *testing.T) {
+	runtime := NewDeterministicAgent(AllowedActionExecutor{
+		ListFiles: func(action Action, context *Context) ActionResult {
+			if context.CurrentTask != ActionListFiles {
+				t.Fatalf("executor current task = %v, expected list files", context.CurrentTask)
+			}
+			return ActionResult{OK: true, Message: MessageFilesListed}
+		},
+	})
+	var input [MaxContextInput]byte
+	copy(input[:], "agent show files")
+	var context Context
+
+	response := runtime.RunActionRequest(
+		ActionListFiles,
+		IntentListFiles,
+		RiskSafe,
+		nil,
+		0,
+		&input,
+		len("agent show files"),
+		&context,
+	)
+
+	if !response.Result.OK {
+		t.Fatalf("expected successful response, got %+v", response)
+	}
+	if context.CurrentTask != ActionNone ||
+		context.LastIntent != IntentListFiles ||
+		context.LastAction != ActionListFiles ||
+		context.LastResultSummary != MessageFilesListed ||
+		context.RequestCount != 1 ||
+		context.PlannerMode != PlannerModeDeterministic ||
+		context.RecentCount != 1 {
+		t.Fatalf("unexpected context: %+v", context)
+	}
+	if got := string(context.LastInput[:context.LastInputLen]); got != "agent show files" {
+		t.Fatalf("last input = %q, expected %q", got, "agent show files")
+	}
+}
+
+func TestLLMPlannerForwardsSessionContext(t *testing.T) {
+	bridge := &contextBridge{
+		plan: singleActionPlan(PlannerModeLLM, IntentListFiles, ActionListFiles, RiskSafe),
+	}
+	context := Context{
+		LastIntent:        IntentReadFile,
+		LastAction:        ActionReadFile,
+		LastResultSummary: MessageFileRead,
+		RequestCount:      3,
+		PlannerMode:       PlannerModeDeterministic,
+	}
+
+	result := (LLMPlanner{Bridge: bridge}).Plan("show files", &context)
+
+	if !result.OK {
+		t.Fatalf("expected successful plan, got %+v", result)
+	}
+	if bridge.context != &context {
+		t.Fatalf("bridge did not receive the session context")
+	}
+	if bridge.context.RequestCount != 3 || bridge.context.LastAction != ActionReadFile {
+		t.Fatalf("bridge received unexpected context: %+v", bridge.context)
+	}
+}
+
 func TestEnumStrings(t *testing.T) {
 	if PlannerModeDeterministic.String() != "deterministic" || PlannerModeLLM.String() != "llm" || PlannerMode(99).String() != stringUnknown {
 		t.Fatalf("unexpected planner mode strings")
@@ -681,7 +757,7 @@ func TestEnumStrings(t *testing.T) {
 }
 
 func TestMessageAgentHelpStringMatchesAgentCommands(t *testing.T) {
-	want := "Agent commands:\n  agent show files    - Show files managed by the agent\n  agent show history  - Show command history stored by the agent\n  agent show version  - Show OS version through the agent\n  agent show ticks    - Show PIT ticks through the agent\n  agent show memorymap - Show memory map through the agent\n  agent read <name>   - Read a file through the agent\n  agent stat <name>   - Show file metadata through the agent\n  agent delete <name> - Delete a file after confirmation\n  agent mode [mode]   - Show or switch agent mode\n  agent help          - Show agent commands"
+	want := "Agent commands:\n  agent show files    - Show files managed by the agent\n  agent show history  - Show command history stored by the agent\n  agent show version  - Show OS version through the agent\n  agent show ticks    - Show PIT ticks through the agent\n  agent show memorymap - Show memory map through the agent\n  agent read <name>   - Read a file through the agent\n  agent stat <name>   - Show file metadata through the agent\n  agent delete <name> - Delete a file after confirmation\n  agent mode [mode]   - Show or switch agent mode\n  agent context       - Show current agent context\n  agent help          - Show agent commands"
 	if got := MessageAgentHelp.String(); got != want {
 		t.Fatalf("MessageAgentHelp.String() = %q, expected %q", got, want)
 	}
@@ -692,6 +768,16 @@ type fakeBridge struct {
 }
 
 func (b fakeBridge) Plan(input string, context *Context) PlanningResult {
+	return successfulPlan(b.plan)
+}
+
+type contextBridge struct {
+	plan    Plan
+	context *Context
+}
+
+func (b *contextBridge) Plan(_ string, context *Context) PlanningResult {
+	b.context = context
 	return successfulPlan(b.plan)
 }
 

--- a/agent/runtime.go
+++ b/agent/runtime.go
@@ -23,6 +23,20 @@ func NewDeterministicAgent(executor AllowedActionExecutor) Runtime {
 }
 
 func (r Runtime) RunAction(kind ActionKind, intent IntentKind, risk RiskLevel, target *[MaxNameLen]byte, targetLen int, context *Context) Response {
+	if context != nil {
+		context.BeginRequest(nil, 0, PlannerModeDeterministic)
+	}
+	return r.runAction(kind, intent, risk, target, targetLen, context)
+}
+
+func (r Runtime) RunActionRequest(kind ActionKind, intent IntentKind, risk RiskLevel, target *[MaxNameLen]byte, targetLen int, input *[MaxContextInput]byte, inputLen int, context *Context) Response {
+	if context != nil {
+		context.BeginRequest(input, inputLen, PlannerModeDeterministic)
+	}
+	return r.runAction(kind, intent, risk, target, targetLen, context)
+}
+
+func (r Runtime) runAction(kind ActionKind, intent IntentKind, risk RiskLevel, target *[MaxNameLen]byte, targetLen int, context *Context) Response {
 	plan := singleActionPlan(PlannerModeDeterministic, intent, kind, risk)
 	if target != nil && targetLen > 0 {
 		if targetLen > MaxNameLen {
@@ -44,6 +58,16 @@ func (r *Runtime) RunActionMessage(kind ActionKind, intent IntentKind, risk Risk
 		return MessageActionTargetInvalid
 	}
 	return r.RunAction(kind, intent, risk, target, targetLen, context).Result.Message
+}
+
+func (r *Runtime) RunActionRequestMessage(kind ActionKind, intent IntentKind, risk RiskLevel, target *[MaxNameLen]byte, targetLen int, input *[MaxContextInput]byte, inputLen int, context *Context) MessageKind {
+	if r == nil {
+		return MessageExecutorNotConfigured
+	}
+	if targetLen < 0 || targetLen > MaxNameLen {
+		return MessageActionTargetInvalid
+	}
+	return r.RunActionRequest(kind, intent, risk, target, targetLen, input, inputLen, context).Result.Message
 }
 
 func (r *Runtime) ConfirmActionMessage(confirmed bool, context *Context) MessageKind {
@@ -68,7 +92,7 @@ func (r Runtime) ConfirmAction(confirmed bool, context *Context) Response {
 		setResponseResult(&response, false, MessageActionCancelled)
 		setSafety(&response, SafetyRejected, MessageActionCancelled)
 		response.AddTrace(TraceSafety, TraceDetailRejected)
-		return response
+		return finishPlanContext(response, context, plan)
 	}
 	return r.runPlanWithConfirmation(plan, context, true)
 }
@@ -87,31 +111,37 @@ func (r Runtime) runPlanWithConfirmation(plan Plan, context *Context, confirmed 
 		setResponseResult(&response, false, validation.Reason)
 		setSafety(&response, SafetyRejected, MessageValidationFailed)
 		response.AddTrace(TraceValidation, traceFromMessage(validation.Reason))
-		return response
+		return finishPlanContext(response, context, plan)
 	}
 	response.AddTrace(TraceValidation, TraceDetailOK)
+	if context != nil {
+		context.CurrentTask = plan.Actions[0].Kind
+	}
 
 	safety := evaluateSafetyWithConfirmation(plan, context, confirmed)
 	setSafety(&response, safety.Status, safety.Reason)
 	response.AddTrace(TraceSafety, safetyTrace(safety.Status))
 	if safety.Status != SafetyAllowed {
 		setResponseResult(&response, false, safety.Reason)
-		return response
+		return finishPlanContext(response, context, plan)
 	}
 
 	if !r.ExecutorConfigured {
 		setResponseResult(&response, false, MessageExecutorNotConfigured)
 		response.AddTrace(TraceExecutor, TraceDetailMissing)
-		return response
+		return finishPlanContext(response, context, plan)
 	}
 
 	var results [MaxActions]ActionResult
 	for i := 0; i < plan.ActionCount; i++ {
+		if context != nil {
+			context.CurrentTask = plan.Actions[i].Kind
+		}
 		results[i] = r.Executor.Execute(plan.Actions[i], context)
 		if !results[i].OK {
 			response.AddTrace(TraceExecutor, TraceDetailFailed)
 			setResponseResult(&response, results[i].OK, results[i].Message)
-			return response
+			return finishPlanContext(response, context, plan)
 		}
 	}
 	response.AddTrace(TraceExecutor, TraceDetailSuccess)
@@ -119,8 +149,26 @@ func (r Runtime) runPlanWithConfirmation(plan Plan, context *Context, confirmed 
 	result := formatResult(plan, results, plan.ActionCount, safety)
 	setResponseResult(&response, result.OK, result.Message)
 	response.AddTrace(TraceFormatter, TraceDetailStructured)
-	if context != nil {
-		context.Remember(plan.Intent)
+	return finishPlanContext(response, context, plan)
+}
+
+func finishPlanContext(response Response, context *Context, plan Plan) Response {
+	if context == nil {
+		return response
+	}
+	context.LastIntent = plan.Intent
+	context.LastAction = ActionNone
+	if plan.ActionCount > 0 {
+		actionIndex := plan.ActionCount - 1
+		if actionIndex >= MaxActions {
+			actionIndex = MaxActions - 1
+		}
+		context.LastAction = plan.Actions[actionIndex].Kind
+	}
+	context.LastResultSummary = response.Result.Message
+	context.PlannerMode = plan.Planner
+	if response.Safety.Status != SafetyConfirmationRequired {
+		context.CurrentTask = ActionNone
 	}
 	return response
 }

--- a/agent/runtime_host.go
+++ b/agent/runtime_host.go
@@ -3,12 +3,21 @@
 package agent
 
 func (r Runtime) Run(input string, context *Context) Response {
+	if context != nil {
+		context.BeginStringRequest(input, PlannerModeDeterministic)
+	}
 	planning := deterministicPlan(input, context)
 	if !planning.OK {
 		var response Response
 		setResponseResult(&response, false, planning.Reason)
 		setSafety(&response, SafetyRejected, MessagePlannerFailed)
 		response.AddTrace(TracePlanner, traceFromMessage(planning.Reason))
+		if context != nil {
+			context.CurrentTask = ActionNone
+			context.LastIntent = IntentUnknown
+			context.LastAction = ActionNone
+			context.LastResultSummary = planning.Reason
+		}
 		return response
 	}
 	return r.runPlan(planning.Plan, context)

--- a/agent/types.go
+++ b/agent/types.go
@@ -6,6 +6,7 @@ const (
 	MaxNameLen      = 16
 	MaxDataLen      = 128
 	MaxRecentItems  = 4
+	MaxContextInput = 128
 )
 
 type PlannerMode uint8
@@ -237,10 +238,42 @@ func (r *Response) AddTrace(stage TraceKind, detail TraceDetail) {
 }
 
 type Context struct {
+	CurrentTask         ActionKind
+	LastInput           [MaxContextInput]byte
+	LastInputLen        int
 	LastIntent          IntentKind
+	LastAction          ActionKind
+	LastResultSummary   MessageKind
+	RequestCount        uint64
+	PlannerMode         PlannerMode
 	RecentCount         int
 	PendingPlan         Plan
 	ConfirmationPending bool
+}
+
+func (c *Context) BeginRequest(input *[MaxContextInput]byte, inputLen int, planner PlannerMode) {
+	if c == nil {
+		return
+	}
+	if inputLen < 0 {
+		inputLen = 0
+	}
+	if inputLen > MaxContextInput {
+		inputLen = MaxContextInput
+	}
+	if input == nil {
+		inputLen = 0
+	}
+	for i := 0; i < inputLen; i++ {
+		c.LastInput[i] = input[i]
+	}
+	c.LastInputLen = inputLen
+	c.RequestCount++
+	c.PlannerMode = planner
+	c.CurrentTask = ActionNone
+	if c.RecentCount < MaxRecentItems {
+		c.RecentCount++
+	}
 }
 
 func (c *Context) Remember(intent IntentKind) {

--- a/agent/types_host.go
+++ b/agent/types_host.go
@@ -22,6 +22,18 @@ const (
 	stringRejected             = "rejected"
 )
 
+func (c *Context) BeginStringRequest(input string, planner PlannerMode) {
+	var request [MaxContextInput]byte
+	inputLen := len(input)
+	if inputLen > MaxContextInput {
+		inputLen = MaxContextInput
+	}
+	for i := 0; i < inputLen; i++ {
+		request[i] = input[i]
+	}
+	c.BeginRequest(&request, inputLen, planner)
+}
+
 func (m PlannerMode) String() string {
 	switch m {
 	case PlannerModeDeterministic:
@@ -162,7 +174,7 @@ func (m MessageKind) String() string {
 	case MessageFileNotFound:
 		return "agent: file not found"
 	case MessageAgentHelp:
-		return "Agent commands:\n  agent show files    - Show files managed by the agent\n  agent show history  - Show command history stored by the agent\n  agent show version  - Show OS version through the agent\n  agent show ticks    - Show PIT ticks through the agent\n  agent show memorymap - Show memory map through the agent\n  agent read <name>   - Read a file through the agent\n  agent stat <name>   - Show file metadata through the agent\n  agent delete <name> - Delete a file after confirmation\n  agent mode [mode]   - Show or switch agent mode\n  agent help          - Show agent commands"
+		return "Agent commands:\n  agent show files    - Show files managed by the agent\n  agent show history  - Show command history stored by the agent\n  agent show version  - Show OS version through the agent\n  agent show ticks    - Show PIT ticks through the agent\n  agent show memorymap - Show memory map through the agent\n  agent read <name>   - Read a file through the agent\n  agent stat <name>   - Show file metadata through the agent\n  agent delete <name> - Delete a file after confirmation\n  agent mode [mode]   - Show or switch agent mode\n  agent context       - Show current agent context\n  agent help          - Show agent commands"
 	case MessageHistoryListed:
 		return "agent: history listed"
 	case MessageVersionShown:

--- a/scripts/test_boot.py
+++ b/scripts/test_boot.py
@@ -120,6 +120,17 @@ def run_functional_suite(iso_path, disk_img, log_file):
             ("version", ["DavOS 0.0.5 (64bit)"]),
             ("write notes hi", ["ok"]),
             ("agent show files", ["notes  size=2", "agent: files listed"]),
+            (
+                "agent context",
+                [
+                    "Agent context:",
+                    "last input: agent show files",
+                    "last intent: list_files",
+                    "last action: list_files",
+                    "request count: 1",
+                    "planner mode: deterministic",
+                ],
+            ),
             ("agent help", ["Agent commands:", "agent delete <name>"]),
             ("agent show history", ["agent: history listed"]),
             ("agent show version", ["DavOS 0.0.5 (64bit)", "agent: version shown"]),

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -1035,11 +1035,12 @@ func printAgentContext(context *agent.Context) {
 	terminal.Print("\n  last action: ")
 	printAgentContextKind(uint8(context.LastAction))
 	terminal.Print("\n  last result: ")
-	if context.LastResultSummary == agent.MessageNone {
+	switch context.LastResultSummary {
+	case agent.MessageNone:
 		terminal.Print("none")
-	} else if context.LastResultSummary == agent.MessageAgentHelp {
+	case agent.MessageAgentHelp:
 		terminal.Print("agent: help shown")
-	} else {
+	default:
 		printAgentMessage(context.LastResultSummary)
 	}
 	terminal.Print("\n  request count: ")

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -58,6 +58,21 @@ var commandBuf = [...]string{
 	"layout", "version", "run", "agent",
 }
 
+var agentContextKindNames = [...]string{
+	"none",
+	"list_files",
+	"read_file",
+	"write_file",
+	"delete_file",
+	"stat_file",
+	"show_help",
+	"show_history",
+	"show_version",
+	"show_ticks",
+	"show_memory_map",
+	"set_mode",
+}
+
 func SetTickProvider(fn func() uint64)        { getTicks = fn }
 func SetSyscallTickProvider(fn func() uint64) { getSyscallTicks = fn }
 func SetProgramRunner(fn func(name *[16]byte, nameLen int) (pid int, ok bool)) {
@@ -793,7 +808,7 @@ func execute() {
 	if matchLiteral(cmdStart, cmdEnd, "agent") {
 		a1s, a1e, ok := nextArg(cmdEnd, end)
 		if !ok {
-			terminal.Print("Usage: agent <show|read|stat|delete|mode|help> [arg]\n")
+			terminal.Print("Usage: agent <show|read|stat|delete|mode|context|help> [arg]\n")
 			return
 		}
 
@@ -804,19 +819,19 @@ func execute() {
 				return
 			}
 			if matchLiteral(a2s, a2e, "files") {
-				runAgentNoTarget(agent.ActionListFiles, agent.IntentListFiles, agent.RiskSafe)
+				runAgentNoTarget(agent.ActionListFiles, agent.IntentListFiles, agent.RiskSafe, start, end)
 				return
 			} else if matchLiteral(a2s, a2e, "history") {
-				runAgentNoTarget(agent.ActionShowHistory, agent.IntentShowHistory, agent.RiskSafe)
+				runAgentNoTarget(agent.ActionShowHistory, agent.IntentShowHistory, agent.RiskSafe, start, end)
 				return
 			} else if matchLiteral(a2s, a2e, "version") {
-				runAgentNoTarget(agent.ActionShowVersion, agent.IntentShowVersion, agent.RiskSafe)
+				runAgentNoTarget(agent.ActionShowVersion, agent.IntentShowVersion, agent.RiskSafe, start, end)
 				return
 			} else if matchLiteral(a2s, a2e, "ticks") {
-				runAgentNoTarget(agent.ActionShowTicks, agent.IntentShowTicks, agent.RiskSafe)
+				runAgentNoTarget(agent.ActionShowTicks, agent.IntentShowTicks, agent.RiskSafe, start, end)
 				return
 			} else if matchLiteral(a2s, a2e, "memorymap") || matchLiteral(a2s, a2e, "memory_map") {
-				runAgentNoTarget(agent.ActionShowMemoryMap, agent.IntentShowMemoryMap, agent.RiskSafe)
+				runAgentNoTarget(agent.ActionShowMemoryMap, agent.IntentShowMemoryMap, agent.RiskSafe, start, end)
 				return
 			}
 			terminal.Print("Usage: agent show <files|history|version|ticks|memorymap>\n")
@@ -827,7 +842,7 @@ func execute() {
 				terminal.Print("Usage: agent read <name>\n")
 				return
 			}
-			runAgentAction(agent.ActionReadFile, agent.IntentReadFile, agent.RiskSafe, a2s, a2e)
+			runAgentAction(agent.ActionReadFile, agent.IntentReadFile, agent.RiskSafe, a2s, a2e, start, end)
 			return
 		} else if matchLiteral(a1s, a1e, "delete") {
 			a2s, a2e, ok := nextArg(a1e, end)
@@ -835,7 +850,7 @@ func execute() {
 				terminal.Print("Usage: agent delete <name>\n")
 				return
 			}
-			runAgentAction(agent.ActionDeleteFile, agent.IntentDeleteFile, agent.RiskRisky, a2s, a2e)
+			runAgentAction(agent.ActionDeleteFile, agent.IntentDeleteFile, agent.RiskRisky, a2s, a2e, start, end)
 			return
 		} else if matchLiteral(a1s, a1e, "stat") {
 			a2s, a2e, ok := nextArg(a1e, end)
@@ -843,18 +858,21 @@ func execute() {
 				terminal.Print("Usage: agent stat <name>\n")
 				return
 			}
-			runAgentAction(agent.ActionStatFile, agent.IntentStatFile, agent.RiskSafe, a2s, a2e)
+			runAgentAction(agent.ActionStatFile, agent.IntentStatFile, agent.RiskSafe, a2s, a2e, start, end)
 			return
 		} else if matchLiteral(a1s, a1e, "mode") {
 			a2s, a2e, ok := nextArg(a1e, end)
 			if ok {
-				runAgentAction(agent.ActionSetMode, agent.IntentSetMode, agent.RiskSafe, a2s, a2e)
+				runAgentAction(agent.ActionSetMode, agent.IntentSetMode, agent.RiskSafe, a2s, a2e, start, end)
 				return
 			}
-			runAgentNoTarget(agent.ActionSetMode, agent.IntentSetMode, agent.RiskSafe)
+			runAgentNoTarget(agent.ActionSetMode, agent.IntentSetMode, agent.RiskSafe, start, end)
+			return
+		} else if matchLiteral(a1s, a1e, "context") {
+			printAgentContext(&agentContext)
 			return
 		} else if matchLiteral(a1s, a1e, "help") {
-			runAgentNoTarget(agent.ActionShowHelp, agent.IntentShowHelp, agent.RiskSafe)
+			runAgentNoTarget(agent.ActionShowHelp, agent.IntentShowHelp, agent.RiskSafe, start, end)
 			return
 		}
 
@@ -890,19 +908,29 @@ func execute() {
 	terminal.PutRune('\n')
 }
 
-func runAgentNoTarget(kind agent.ActionKind, intent agent.IntentKind, risk agent.RiskLevel) {
-	message := runtimeAgent.RunActionMessage(kind, intent, risk, nil, 0, &agentContext)
+func runAgentNoTarget(kind agent.ActionKind, intent agent.IntentKind, risk agent.RiskLevel, inputStart, inputEnd int) {
+	var input [agent.MaxContextInput]byte
+	inputLen := inputEnd - inputStart
+	for i := 0; i < inputLen; i++ {
+		input[i] = lineBuf[inputStart+i]
+	}
+	message := runtimeAgent.RunActionRequestMessage(kind, intent, risk, nil, 0, &input, inputLen, &agentContext)
 	printAgentMessage(message)
 	terminal.PutRune('\n')
 }
 
-func runAgentAction(kind agent.ActionKind, intent agent.IntentKind, risk agent.RiskLevel, targetStart, targetEnd int) {
+func runAgentAction(kind agent.ActionKind, intent agent.IntentKind, risk agent.RiskLevel, targetStart, targetEnd, inputStart, inputEnd int) {
 	targetLen, ok := copyNameFromRange(targetStart, targetEnd)
 	if !ok {
 		terminal.Print("agent: invalid target\n")
 		return
 	}
-	message := runtimeAgent.RunActionMessage(kind, intent, risk, &tmpName, targetLen, &agentContext)
+	var input [agent.MaxContextInput]byte
+	inputLen := inputEnd - inputStart
+	for i := 0; i < inputLen; i++ {
+		input[i] = lineBuf[inputStart+i]
+	}
+	message := runtimeAgent.RunActionRequestMessage(kind, intent, risk, &tmpName, targetLen, &input, inputLen, &agentContext)
 	if message == agent.MessageConfirmationRequired && kind == agent.ActionDeleteFile {
 		terminal.Print("Agent understood: delete file \"")
 		printName(&tmpName, targetLen)
@@ -969,6 +997,7 @@ func printAgentMessage(message agent.MessageKind) {
 		terminal.Print("  agent stat <name>   - Show file metadata through the agent\n")
 		terminal.Print("  agent delete <name> - Delete a file after confirmation\n")
 		terminal.Print("  agent mode [mode]   - Show or switch agent mode\n")
+		terminal.Print("  agent context       - Show current agent context\n")
 		terminal.Print("  agent help          - Show agent commands")
 	case agent.MessageHistoryListed:
 		terminal.Print("agent: history listed")
@@ -987,6 +1016,48 @@ func printAgentMessage(message agent.MessageKind) {
 	default:
 		return
 	}
+}
+
+func printAgentContext(context *agent.Context) {
+	terminal.Print("Agent context:\n")
+	terminal.Print("  current task: ")
+	printAgentContextKind(uint8(context.CurrentTask))
+	terminal.Print("\n  last input: ")
+	if context.LastInputLen == 0 {
+		terminal.Print("none")
+	} else {
+		for i := 0; i < context.LastInputLen; i++ {
+			terminal.PutRune(rune(context.LastInput[i]))
+		}
+	}
+	terminal.Print("\n  last intent: ")
+	printAgentContextKind(uint8(context.LastIntent))
+	terminal.Print("\n  last action: ")
+	printAgentContextKind(uint8(context.LastAction))
+	terminal.Print("\n  last result: ")
+	if context.LastResultSummary == agent.MessageNone {
+		terminal.Print("none")
+	} else if context.LastResultSummary == agent.MessageAgentHelp {
+		terminal.Print("agent: help shown")
+	} else {
+		printAgentMessage(context.LastResultSummary)
+	}
+	terminal.Print("\n  request count: ")
+	printUint(context.RequestCount)
+	terminal.Print("\n  planner mode: ")
+	if context.PlannerMode == agent.PlannerModeLLM {
+		terminal.Print("llm")
+	} else {
+		terminal.Print("deterministic")
+	}
+	terminal.PutRune('\n')
+}
+
+func printAgentContextKind(kind uint8) {
+	if int(kind) >= len(agentContextKindNames) {
+		kind = 0
+	}
+	terminal.Print(agentContextKindNames[kind])
 }
 
 func printHistory() {

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -465,7 +465,7 @@ func TestExecuteAgentCommand(t *testing.T) {
 		{
 			name:  "missing command",
 			input: "agent",
-			want:  "Usage: agent <show|read|stat|delete|mode|help> [arg]\n",
+			want:  "Usage: agent <show|read|stat|delete|mode|context|help> [arg]\n",
 		},
 		{
 			name:  "missing show argument",
@@ -525,7 +525,7 @@ func TestExecuteAgentCommand(t *testing.T) {
 		{
 			name:  "help",
 			input: "agent help",
-			want:  "Agent commands:\n  agent show files    - Show files managed by the agent\n  agent show history  - Show command history stored by the agent\n  agent show version  - Show OS version through the agent\n  agent show ticks    - Show PIT ticks through the agent\n  agent show memorymap - Show memory map through the agent\n  agent read <name>   - Read a file through the agent\n  agent stat <name>   - Show file metadata through the agent\n  agent delete <name> - Delete a file after confirmation\n  agent mode [mode]   - Show or switch agent mode\n  agent help          - Show agent commands\n",
+			want:  "Agent commands:\n  agent show files    - Show files managed by the agent\n  agent show history  - Show command history stored by the agent\n  agent show version  - Show OS version through the agent\n  agent show ticks    - Show PIT ticks through the agent\n  agent show memorymap - Show memory map through the agent\n  agent read <name>   - Read a file through the agent\n  agent stat <name>   - Show file metadata through the agent\n  agent delete <name> - Delete a file after confirmation\n  agent mode [mode]   - Show or switch agent mode\n  agent context       - Show current agent context\n  agent help          - Show agent commands\n",
 		},
 	}
 
@@ -575,6 +575,36 @@ func TestExecuteAgentShowFilesUsesDefaultRuntime(t *testing.T) {
 
 	if got := terminal.OutputForTesting(); got != "agent: no files\n" {
 		t.Fatalf("execute(%q) output = %q, expected %q", "agent show files", got, "agent: no files\n")
+	}
+}
+
+func TestExecuteAgentContextShowsSessionState(t *testing.T) {
+	fs.Init()
+	runtime := agent.NewDeterministicAgent(NewAgentExecutor())
+	SetAgentRuntime(&runtime)
+	t.Cleanup(func() {
+		SetAgentRuntime(nil)
+	})
+
+	terminal.Init()
+	terminal.ResetOutputForTesting()
+	setLineBuf("agent show files")
+	execute()
+
+	terminal.ResetOutputForTesting()
+	setLineBuf("agent context")
+	execute()
+
+	want := "Agent context:\n" +
+		"  current task: none\n" +
+		"  last input: agent show files\n" +
+		"  last intent: list_files\n" +
+		"  last action: list_files\n" +
+		"  last result: agent: no files\n" +
+		"  request count: 1\n" +
+		"  planner mode: deterministic\n"
+	if got := terminal.OutputForTesting(); got != want {
+		t.Fatalf("agent context output = %q, expected %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## What

- Keep fixed-size, session-local Agent context for the current task, last input, intent, action, result, request count, and planner mode.
- Update context across successful, failed, pending, confirmed, and cancelled actions.
- Add `agent context` output plus unit, shell, bridge-forwarding, and QEMU functional coverage.

## Why

The Agent runtime only remembered the last intent and pending confirmation. The next LLM-backed planner needs useful session state that can be passed through the existing `BridgeClient` boundary.

Closes #161

## How to test

- `gofmt -l .`
- `go vet -tags testing -unsafeptr=false ./...`
- `make test`
- `python3 -m py_compile scripts/test_boot.py`
- In QEMU: run `agent show files`, then `agent context`, and verify the previous request and result are shown.

## Pre-flight

- [x] `gofmt -l .` prints nothing
- [x] `go vet -tags testing -unsafeptr=false ./...` is clean
- [x] `make test` passes
- [ ] `python3 scripts/test_boot.py` passes (not run locally because the `x86_64-elf-*` cross-toolchain is unavailable)
- [x] PR is a single concern (no drive-by cleanups)

AI was used for assistance.