### PR TITLE
Highlight the v0.5.0 Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,36 @@
 Hobby project to dig deeper into how an OS works by writing the bare essentials of a kernel in Go. Only the kernel lives here (gccgo, x86_64 long mode); BIOS and bootloader are handled by battle-tested tools (GRUB with a Multiboot2 header). No reinvention of those pieces.
 Join [Discord](https://discord.gg/mBHhPZ65eW) for real time discussions on the project ! 
 
+## Agentic OS
+
+Starting with `v0.5.0`, go-dav-os includes its first **Minimum Working Agent**: a small, inspectable runtime that turns user intent into typed actions instead of arbitrary shell commands.
+
+The current Agent foundation includes:
+
+- a deterministic planner that runs entirely inside the OS;
+- typed plans, a fixed action allowlist and validation before execution;
+- an explicit safety gate for risky actions such as file deletion;
+- structured execution traces and session-local context;
+- an LLM planner boundary, bridge protocol and fake host bridge for testing without API keys.
+
+The trust boundary is deliberate: an LLM may propose one allowed typed action, but the OS remains responsible for validation, confirmation and execution. `v0.5.0` establishes this secure foundation. The real QEMU guest-to-host transport and an OpenAI-compatible provider are planned for `v0.6.0`; provider credentials will remain outside the guest and kernel.
+
+### Try the Agent in QEMU
+
+```text
+agent show files
+agent read notes
+agent delete notes
+yes
+agent context
+agent mode
+```
+
+Read the [Agent runtime architecture](docs/v0.5.0/agent_runtime.md), [LLM bridge protocol](docs/v0.5.0/llm_bridge_protocol.md) and [fake bridge guide](docs/v0.5.0/fake_llm_bridge.md).
+
 ## What’s inside
+
+- Agent runtime: `agent/` implements typed planning, validation, safety, constrained execution, context and LLM bridge contracts
 
 - Boot: `boot/boot.s` exposes the Multiboot2 header and `_start`, sets up a 16 KB stack, enables long mode, and jumps into `kernel.Main`
   - The Multiboot2 info pointer is passed to `kernel.Main(...)` in `RDI`
@@ -103,6 +132,7 @@ If you run into issues while building or running the project, check these common
 - `pfa`, `alloc`, `free <hex_addr>` (page allocator)
 - `ls`, `write <name> <text...>`, `cat <name>`, `rm <name>`, `stat <name>` (in-memory filesystem)
 - `run <program>` (task runner)
+- `agent <show|read|stat|delete|mode|context|help> [arg]` (typed Agent runtime)
 
 ### Persistent Storage (FAT16)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Starting with `v0.5.0`, go-dav-os includes its first **Minimum Working Agent**: 
 
 The current Agent foundation includes:
 
-- a deterministic planner that runs entirely inside the OS;
+- a deterministic planner foundation for host-side tests, while the QEMU shell maps supported `agent` subcommands directly to typed actions;
 - typed plans, a fixed action allowlist and validation before execution;
 - an explicit safety gate for risky actions such as file deletion;
 - structured execution traces and session-local context;
@@ -20,6 +20,7 @@ The trust boundary is deliberate: an LLM may propose one allowed typed action, b
 ### Try the Agent in QEMU
 
 ```text
+write notes hi
 agent show files
 agent read notes
 agent delete notes

--- a/scripts/test_boot.py
+++ b/scripts/test_boot.py
@@ -117,7 +117,7 @@ def run_functional_suite(iso_path, disk_img, log_file):
 
         test_cases = [
             ("help", ["Commands:", "agent"]),
-            ("version", ["DavOS 0.0.5 (64bit)"]),
+            ("version", ["DavOS 0.5.0 (64bit)"]),
             ("write notes hi", ["ok"]),
             ("agent show files", ["notes  size=2", "agent: files listed"]),
             (
@@ -133,7 +133,7 @@ def run_functional_suite(iso_path, disk_img, log_file):
             ),
             ("agent help", ["Agent commands:", "agent delete <name>"]),
             ("agent show history", ["agent: history listed"]),
-            ("agent show version", ["DavOS 0.0.5 (64bit)", "agent: version shown"]),
+            ("agent show version", ["DavOS 0.5.0 (64bit)", "agent: version shown"]),
             ("agent show ticks", ["agent: ticks shown"]),
             ("agent show memorymap", ["base=0x", "agent: memory map shown"]),
             ("agent read notes", ["hi", "agent: file read"]),

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -16,7 +16,7 @@ const (
 	maxLine              = 128
 	osName               = "DavOS"
 	maxDistanceThreshold = 3
-	osVersion            = "0.0.5"
+	osVersion            = "0.5.0"
 	commandHelp          = "help"
 	commandHistory       = "history"
 )

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -475,7 +475,7 @@ func TestExecuteAgentCommand(t *testing.T) {
 		{
 			name:  "show version",
 			input: "agent show version",
-			want:  "DavOS 0.0.5 (64bit)\nagent: version shown\n",
+			want:  "DavOS 0.5.0 (64bit)\nagent: version shown\n",
 		},
 		{
 			name:  "show ticks",


### PR DESCRIPTION
## What

- add a prominent Agentic OS section to the README
- summarize the v0.5.0 deterministic Agent, typed action boundary, validation, safety gate, context and fake LLM bridge
- add a QEMU command walkthrough and links to the v0.5.0 Agent documentation
- state the current v0.5.0 boundary and defer real transport/provider integration to v0.6.0
- align the shell version output and test expectations from `0.0.5` to `0.5.0`

## Why

The v0.5.0 Agent is the project's main new direction, but the README did not expose it and the runtime still reported the old version. This makes the released capability visible without implying that the real guest-to-host LLM round trip already exists.

## Validation

- verified the branch differs from `main` only in `README.md`, `shell/shell.go`, `shell/shell_test.go` and `scripts/test_boot.py`
- verified no `0.0.5` expectation remains in the changed files
- automated unit, lint, ISO and QEMU checks are delegated to the PR CI

Follow-up to #150.