### PR TITLE
Add QEMU guest-host Agent transport

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ AS       := $(CROSS)-as
 GCC      := $(CROSS)-gcc
 GCCGO    := $(CROSS)-gccgo
 OBJCOPY  := $(CROSS)-objcopy
-GCCGOFLAGS := -m64 -mno-sse -mno-sse2 -mno-mmx
+GCCGOFLAGS := -m64 -mno-red-zone -mno-sse -mno-sse2 -mno-mmx
 GRUB_CFG      := iso/grub/grub.cfg
 
 GRUBMKRESCUE  := grub-mkrescue

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ GRUB_CFG      := iso/grub/grub.cfg
 
 GRUBMKRESCUE  := grub-mkrescue
 QEMU          := qemu-system-x86_64
+AGENT_SERIAL_SOCKET ?= /tmp/davos-agent.sock
 
 DOCKER_PLATFORM := linux/amd64
 DOCKER_IMAGE    := go-dav-os-toolchain
@@ -29,6 +30,7 @@ KEYBOARD_IMPORT  := $(MODPATH)/keyboard
 KEYBOARD_LAYOUT_IMPORT := $(MODPATH)/keyboard/layout
 SHELL_IMPORT     := $(MODPATH)/shell
 AGENT_IMPORT     := $(MODPATH)/agent
+SERIAL_IMPORT    := $(MODPATH)/serial
 MEM_IMPORT     := $(MODPATH)/mem
 FS_IMPORT := $(MODPATH)/fs
 ATA_IMPORT := $(MODPATH)/drivers/ata
@@ -45,6 +47,7 @@ KEYBOARD_SRCS := $(filter-out %_test.go %stubs.go, $(wildcard keyboard/*.go))
 KEYBOARD_LAYOUT_SRCS := $(filter-out %_test.go, $(wildcard keyboard/layout/*.go))
 SHELL_SRCS := $(filter-out %_test.go %stubs.go, $(wildcard shell/*.go))
 AGENT_SRCS := $(filter-out %_test.go %stubs.go %_host.go %_llm.go, $(wildcard agent/*.go))
+SERIAL_SRCS := serial/frame.go serial/transport.go serial/io_gccgo.go
 MEM_SRCS       := $(filter-out %_test.go %_stub.go %stubs.go, $(wildcard mem/*.go))
 FS_SRCS   := $(filter-out %_test.go %stubs.go %_host.go %testing.go, $(wildcard fs/*.go))
 ATA_SRCS  := drivers/ata/ata.go drivers/ata/ata_gccgo.go
@@ -69,6 +72,8 @@ SHELL_OBJ   := $(BUILD_DIR)/shell.o
 SHELL_GOX   := $(BUILD_DIR)/github.com/dmarro89/go-dav-os/shell.gox
 AGENT_OBJ   := $(BUILD_DIR)/agent.o
 AGENT_GOX   := $(BUILD_DIR)/github.com/dmarro89/go-dav-os/agent.gox
+SERIAL_OBJ  := $(BUILD_DIR)/serial.o
+SERIAL_GOX  := $(BUILD_DIR)/github.com/dmarro89/go-dav-os/serial.gox
 MEM_OBJ   := $(BUILD_DIR)/mem.o
 MEM_GOX        := $(BUILD_DIR)/github.com/dmarro89/go-dav-os/mem.gox
 FS_OBJ    := $(BUILD_DIR)/fs.o
@@ -87,7 +92,7 @@ GDT_GOX := $(BUILD_DIR)/github.com/dmarro89/go-dav-os/kernel/gdt.gox
 TSS_GOX := $(BUILD_DIR)/github.com/dmarro89/go-dav-os/kernel/tss.gox
 SYSCALL_GOX := $(BUILD_DIR)/github.com/dmarro89/go-dav-os/kernel/syscall.gox
 
-.PHONY: all kernel iso run clean docker-build docker-shell docker-run test
+.PHONY: all kernel iso run run-agent-transport clean docker-build docker-shell docker-run test
 
 all: $(ISO_IMAGE)
 
@@ -97,6 +102,11 @@ iso: $(ISO_IMAGE)
 
 run: $(ISO_IMAGE) disk.img
 	$(QEMU) -cdrom $(ISO_IMAGE) -drive file=disk.img,format=raw
+
+run-agent-transport: $(ISO_IMAGE) disk.img
+	rm -f "$(AGENT_SERIAL_SOCKET)"
+	$(QEMU) -cdrom $(ISO_IMAGE) -drive file=disk.img,format=raw \
+		-serial unix:$(AGENT_SERIAL_SOCKET),server=on,wait=off
 
 disk.img:
 	dd if=/dev/zero of=disk.img bs=1M count=20
@@ -192,7 +202,16 @@ $(AGENT_GOX): $(AGENT_OBJ) | $(BUILD_DIR)
 	mkdir -p $(dir $(AGENT_GOX))
 	$(OBJCOPY) -j .go_export $(AGENT_OBJ) $(AGENT_GOX)
 
-$(SHELL_OBJ): $(SHELL_SRCS) $(AGENT_GOX) $(TERMINAL_GOX) $(MEM_GOX) $(FS_GOX) $(ATA_GOX) $(FAT16_GOX) | $(BUILD_DIR)
+$(SERIAL_OBJ): $(SERIAL_SRCS) | $(BUILD_DIR)
+	$(GCCGO) $(GCCGOFLAGS) -static -Werror -nostdlib -nostartfiles -nodefaultlibs \
+		-fgo-pkgpath=$(SERIAL_IMPORT) \
+		-c $(SERIAL_SRCS) -o $(SERIAL_OBJ)
+
+$(SERIAL_GOX): $(SERIAL_OBJ) | $(BUILD_DIR)
+	mkdir -p $(dir $(SERIAL_GOX))
+	$(OBJCOPY) -j .go_export $(SERIAL_OBJ) $(SERIAL_GOX)
+
+$(SHELL_OBJ): $(SHELL_SRCS) $(AGENT_GOX) $(SERIAL_GOX) $(TERMINAL_GOX) $(MEM_GOX) $(FS_GOX) $(ATA_GOX) $(FAT16_GOX) | $(BUILD_DIR)
 	$(GCCGO) $(GCCGOFLAGS) -static -Werror -nostdlib -nostartfiles -nodefaultlibs \
 		-I $(BUILD_DIR) \
 		-fgo-pkgpath=$(SHELL_IMPORT) \
@@ -265,10 +284,10 @@ $(KERNEL_OBJ): $(KERNEL_SRCS) $(AGENT_GOX) $(TERMINAL_GOX) $(KEYBOARD_GOX) $(KEY
 # -----------------------
 # Link: boot.o + kernel.o -> kernel.elf
 # -----------------------
-$(KERNEL_ELF): $(BOOT_OBJ) $(USER_HELLO_OBJ) $(TERMINAL_OBJ) $(KEYBOARD_LAYOUT_OBJ) $(KEYBOARD_OBJ) $(SHELL_OBJ) $(AGENT_OBJ) $(MEM_OBJ) $(FS_OBJ) $(ATA_OBJ) $(FAT16_OBJ) $(SCHEDULER_OBJ) $(GDT_OBJ) $(TSS_OBJ) $(SYSCALL_OBJ) $(SCH_SWITCH_OBJ) $(KERNEL_OBJ) $(LINKER_SCRIPT)
+$(KERNEL_ELF): $(BOOT_OBJ) $(USER_HELLO_OBJ) $(TERMINAL_OBJ) $(KEYBOARD_LAYOUT_OBJ) $(KEYBOARD_OBJ) $(SHELL_OBJ) $(AGENT_OBJ) $(SERIAL_OBJ) $(MEM_OBJ) $(FS_OBJ) $(ATA_OBJ) $(FAT16_OBJ) $(SCHEDULER_OBJ) $(GDT_OBJ) $(TSS_OBJ) $(SYSCALL_OBJ) $(SCH_SWITCH_OBJ) $(KERNEL_OBJ) $(LINKER_SCRIPT)
 	$(GCC) -T $(LINKER_SCRIPT) -o $(KERNEL_ELF) \
 		-ffreestanding -O2 -nostdlib \
-		$(BOOT_OBJ) $(USER_HELLO_OBJ) $(TERMINAL_OBJ) $(KEYBOARD_LAYOUT_OBJ) $(KEYBOARD_OBJ) $(SHELL_OBJ) $(AGENT_OBJ) $(MEM_OBJ) $(FS_OBJ) $(ATA_OBJ) $(FAT16_OBJ) $(SCHEDULER_OBJ) $(GDT_OBJ) $(TSS_OBJ) $(SYSCALL_OBJ) $(SCH_SWITCH_OBJ) $(KERNEL_OBJ) -lgcc
+		$(BOOT_OBJ) $(USER_HELLO_OBJ) $(TERMINAL_OBJ) $(KEYBOARD_LAYOUT_OBJ) $(KEYBOARD_OBJ) $(SHELL_OBJ) $(AGENT_OBJ) $(SERIAL_OBJ) $(MEM_OBJ) $(FS_OBJ) $(ATA_OBJ) $(FAT16_OBJ) $(SCHEDULER_OBJ) $(GDT_OBJ) $(TSS_OBJ) $(SYSCALL_OBJ) $(SCH_SWITCH_OBJ) $(KERNEL_OBJ) -lgcc
 
 # -----------------------
 # ISO with GRUB

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -861,7 +861,7 @@ func TestEnumStrings(t *testing.T) {
 }
 
 func TestMessageAgentHelpStringMatchesAgentCommands(t *testing.T) {
-	want := "Agent commands:\n  agent show files    - Show files managed by the agent\n  agent show history  - Show command history stored by the agent\n  agent show version  - Show OS version through the agent\n  agent show ticks    - Show PIT ticks through the agent\n  agent show memorymap - Show memory map through the agent\n  agent read <name>   - Read a file through the agent\n  agent stat <name>   - Show file metadata through the agent\n  agent delete <name> - Delete a file after confirmation\n  agent mode [mode]   - Show or switch agent mode\n  agent context       - Show current agent context\n  agent help          - Show agent commands"
+	want := "Agent commands:\n  agent show files    - Show files managed by the agent\n  agent show history  - Show command history stored by the agent\n  agent show version  - Show OS version through the agent\n  agent show ticks    - Show PIT ticks through the agent\n  agent show memorymap - Show memory map through the agent\n  agent read <name>   - Read a file through the agent\n  agent stat <name>   - Show file metadata through the agent\n  agent delete <name> - Delete a file after confirmation\n  agent mode [mode]   - Show or switch agent mode\n  agent transport ping - Probe the guest-host transport\n  agent context       - Show current agent context\n  agent help          - Show agent commands"
 	if got := MessageAgentHelp.String(); got != want {
 		t.Fatalf("MessageAgentHelp.String() = %q, expected %q", got, want)
 	}

--- a/agent/types_host.go
+++ b/agent/types_host.go
@@ -174,7 +174,7 @@ func (m MessageKind) String() string {
 	case MessageFileNotFound:
 		return "agent: file not found"
 	case MessageAgentHelp:
-		return "Agent commands:\n  agent show files    - Show files managed by the agent\n  agent show history  - Show command history stored by the agent\n  agent show version  - Show OS version through the agent\n  agent show ticks    - Show PIT ticks through the agent\n  agent show memorymap - Show memory map through the agent\n  agent read <name>   - Read a file through the agent\n  agent stat <name>   - Show file metadata through the agent\n  agent delete <name> - Delete a file after confirmation\n  agent mode [mode]   - Show or switch agent mode\n  agent context       - Show current agent context\n  agent help          - Show agent commands"
+		return "Agent commands:\n  agent show files    - Show files managed by the agent\n  agent show history  - Show command history stored by the agent\n  agent show version  - Show OS version through the agent\n  agent show ticks    - Show PIT ticks through the agent\n  agent show memorymap - Show memory map through the agent\n  agent read <name>   - Read a file through the agent\n  agent stat <name>   - Show file metadata through the agent\n  agent delete <name> - Delete a file after confirmation\n  agent mode [mode]   - Show or switch agent mode\n  agent transport ping - Probe the guest-host transport\n  agent context       - Show current agent context\n  agent help          - Show agent commands"
 	case MessageHistoryListed:
 		return "agent: history listed"
 	case MessageVersionShown:

--- a/docs/v0.6.0/agent_transport.md
+++ b/docs/v0.6.0/agent_transport.md
@@ -1,0 +1,82 @@
+# v0.6.0 QEMU Agent Transport
+
+Issue #184 adds the first bounded byte transport between the QEMU guest and a
+host process. It carries one Agent request and one response at a time. It does
+not parse JSON, call a provider, execute a shell command, or move credentials
+into the guest.
+
+## QEMU endpoint
+
+The guest uses the first emulated serial port (COM1, I/O base `0x3F8`) in
+polled 38400 8N1 mode. QEMU exposes that port as a Unix stream socket on the
+host:
+
+```sh
+make run-agent-transport
+```
+
+The default socket is `/tmp/davos-agent.sock`. Override it when needed:
+
+```sh
+make run-agent-transport AGENT_SERIAL_SOCKET=/tmp/my-davos-agent.sock
+```
+
+After QEMU starts, attach the one-shot host probe in another terminal:
+
+```sh
+python3 scripts/agent_transport_probe.py --socket /tmp/davos-agent.sock
+```
+
+Then run this command in DavOS:
+
+```text
+agent transport ping
+```
+
+The guest sends a framed `ping`; the host validates it and returns a framed
+`pong`. A successful round trip prints `Agent transport: connected`. The probe
+contains no provider or networking logic and exists only to verify the channel.
+
+## Wire frame
+
+Every integer uses network byte order (big-endian).
+
+| Offset | Size | Field | Value |
+|---:|---:|---|---|
+| 0 | 2 | Magic | ASCII `DV` |
+| 2 | 1 | Version | `1` |
+| 3 | 1 | Kind | `1` request, `2` response |
+| 4 | 2 | Payload length | Number of payload bytes |
+| 6 | N | Payload | Opaque bounded bytes |
+| 6 + N | 2 | Checksum | CRC-16/CCITT-FALSE |
+
+The checksum covers version, kind, payload length and payload. Magic bytes are
+not included.
+
+Limits:
+
+- request payload: 2048 bytes maximum;
+- response payload: 1024 bytes maximum;
+- one in-flight request;
+- no multiplexing or concurrent exchanges.
+
+These limits are checked before payload bytes are copied. The guest uses only
+fixed-size storage.
+
+## Failure behavior
+
+Bad magic, version, kind or checksum is rejected as malformed framing. A length
+over the limit is rejected immediately. If a frame stops partway through, the
+fixed serial poll budget expires and the exchange returns a partial-frame
+error. A later exchange starts with a reset decoder and drains buffered input.
+
+All read and write loops have a fixed upper bound, so an unavailable or broken
+host cannot hold the shell indefinitely. `agent transport ping` reports the
+transport error and returns to the prompt. Higher-level request timeouts,
+bridge health and planner fallback remain part of issue #188.
+
+## Trust boundary
+
+The serial payload is untrusted transport data. Future bridge responses must
+still pass the existing Agent plan validation, safety gate and constrained
+executor. Provider API keys, HTTP calls and JSON parsing remain host-only.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,3 +18,4 @@ nav:
   - v0.5.0 Agent Runtime: v0.5.0/agent_runtime.md
   - v0.5.0 LLM Bridge Protocol: v0.5.0/llm_bridge_protocol.md
   - v0.5.0 Fake LLM Bridge: v0.5.0/fake_llm_bridge.md
+  - v0.6.0 QEMU Agent Transport: v0.6.0/agent_transport.md

--- a/scripts/agent_transport_probe.py
+++ b/scripts/agent_transport_probe.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Serve one framed transport probe over the QEMU Agent serial socket."""
+
+import argparse
+import binascii
+import socket
+import time
+
+
+MAGIC = b"DV"
+VERSION = 1
+REQUEST = 1
+RESPONSE = 2
+HEADER_SIZE = 6
+MAX_REQUEST_PAYLOAD = 2048
+MAX_RESPONSE_PAYLOAD = 1024
+
+
+class ProtocolError(Exception):
+    pass
+
+
+def checksum(data):
+    return binascii.crc_hqx(data, 0xFFFF)
+
+
+def read_exact(stream, size):
+    data = bytearray()
+    while len(data) < size:
+        chunk = stream.recv(size - len(data))
+        if not chunk:
+            raise ProtocolError("partial frame")
+        data.extend(chunk)
+    return bytes(data)
+
+
+def read_request(stream):
+    header = read_exact(stream, HEADER_SIZE)
+    if header[:2] != MAGIC or header[2] != VERSION or header[3] != REQUEST:
+        raise ProtocolError("malformed request header")
+    payload_len = int.from_bytes(header[4:6], "big")
+    if payload_len > MAX_REQUEST_PAYLOAD:
+        raise ProtocolError("request payload is too large")
+    body = read_exact(stream, payload_len + 2)
+    payload = body[:-2]
+    received_checksum = int.from_bytes(body[-2:], "big")
+    if received_checksum != checksum(header[2:] + payload):
+        raise ProtocolError("request checksum mismatch")
+    return payload
+
+
+def encode_response(payload):
+    if len(payload) > MAX_RESPONSE_PAYLOAD:
+        raise ProtocolError("response payload is too large")
+    header = MAGIC + bytes((VERSION, RESPONSE)) + len(payload).to_bytes(2, "big")
+    return header + payload + checksum(header[2:] + payload).to_bytes(2, "big")
+
+
+def connect(path, timeout):
+    deadline = time.monotonic() + timeout
+    while True:
+        stream = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        stream.settimeout(timeout)
+        try:
+            stream.connect(path)
+            return stream
+        except (FileNotFoundError, ConnectionRefusedError):
+            stream.close()
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(0.05)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--socket", default="/tmp/davos-agent.sock")
+    parser.add_argument("--timeout", type=float, default=5.0)
+    args = parser.parse_args()
+
+    with connect(args.socket, args.timeout) as stream:
+        request = read_request(stream)
+        if request != b"ping":
+            raise ProtocolError("unexpected probe payload")
+        stream.sendall(encode_response(b"pong"))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/agent_transport_probe.py
+++ b/scripts/agent_transport_probe.py
@@ -70,10 +70,13 @@ def encode_response(payload):
 def connect(path, deadline):
     while True:
         stream = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        stream.settimeout(remaining_timeout(deadline))
         try:
+            stream.settimeout(remaining_timeout(deadline))
             stream.connect(path)
             return stream
+        except ProtocolError:
+            stream.close()
+            raise
         except socket.timeout as error:
             stream.close()
             raise ProtocolError("probe timed out") from error

--- a/scripts/agent_transport_probe.py
+++ b/scripts/agent_transport_probe.py
@@ -24,24 +24,35 @@ def checksum(data):
     return binascii.crc_hqx(data, 0xFFFF)
 
 
-def read_exact(stream, size):
+def remaining_timeout(deadline):
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise ProtocolError("probe timed out")
+    return remaining
+
+
+def read_exact(stream, size, deadline):
     data = bytearray()
     while len(data) < size:
-        chunk = stream.recv(size - len(data))
+        stream.settimeout(remaining_timeout(deadline))
+        try:
+            chunk = stream.recv(size - len(data))
+        except socket.timeout as error:
+            raise ProtocolError("probe timed out") from error
         if not chunk:
             raise ProtocolError("partial frame")
         data.extend(chunk)
     return bytes(data)
 
 
-def read_request(stream):
-    header = read_exact(stream, HEADER_SIZE)
+def read_request(stream, deadline):
+    header = read_exact(stream, HEADER_SIZE, deadline)
     if header[:2] != MAGIC or header[2] != VERSION or header[3] != REQUEST:
         raise ProtocolError("malformed request header")
     payload_len = int.from_bytes(header[4:6], "big")
     if payload_len > MAX_REQUEST_PAYLOAD:
         raise ProtocolError("request payload is too large")
-    body = read_exact(stream, payload_len + 2)
+    body = read_exact(stream, payload_len + 2, deadline)
     payload = body[:-2]
     received_checksum = int.from_bytes(body[-2:], "big")
     if received_checksum != checksum(header[2:] + payload):
@@ -56,19 +67,19 @@ def encode_response(payload):
     return header + payload + checksum(header[2:] + payload).to_bytes(2, "big")
 
 
-def connect(path, timeout):
-    deadline = time.monotonic() + timeout
+def connect(path, deadline):
     while True:
         stream = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        stream.settimeout(timeout)
+        stream.settimeout(remaining_timeout(deadline))
         try:
             stream.connect(path)
             return stream
+        except socket.timeout as error:
+            stream.close()
+            raise ProtocolError("probe timed out") from error
         except (FileNotFoundError, ConnectionRefusedError):
             stream.close()
-            if time.monotonic() >= deadline:
-                raise
-            time.sleep(0.05)
+            time.sleep(min(0.05, remaining_timeout(deadline)))
 
 
 def main():
@@ -77,11 +88,16 @@ def main():
     parser.add_argument("--timeout", type=float, default=5.0)
     args = parser.parse_args()
 
-    with connect(args.socket, args.timeout) as stream:
-        request = read_request(stream)
+    deadline = time.monotonic() + args.timeout
+    with connect(args.socket, deadline) as stream:
+        request = read_request(stream, deadline)
         if request != b"ping":
             raise ProtocolError("unexpected probe payload")
-        stream.sendall(encode_response(b"pong"))
+        stream.settimeout(remaining_timeout(deadline))
+        try:
+            stream.sendall(encode_response(b"pong"))
+        except socket.timeout as error:
+            raise ProtocolError("probe timed out") from error
 
 
 if __name__ == "__main__":

--- a/scripts/test_boot.py
+++ b/scripts/test_boot.py
@@ -22,7 +22,7 @@ def create_disk_image(disk_img):
         f.write(b"\0" * (20 * 1024 * 1024))
 
 
-def start_qemu(iso_path, disk_img, log_file):
+def start_qemu(iso_path, disk_img, log_file, serial_socket=None):
     cmd = [
         "qemu-system-x86_64",
         "-cdrom",
@@ -31,15 +31,25 @@ def start_qemu(iso_path, disk_img, log_file):
         f"file={disk_img},format=raw",
         "-debugcon",
         f"file:{log_file}",
-        "-serial",
-        "none",
-        "-monitor",
-        "stdio",
-        "-display",
-        "none",
-        "-no-reboot",
-        "-no-shutdown",
     ]
+    if serial_socket:
+        if os.path.exists(serial_socket):
+            os.remove(serial_socket)
+        cmd.extend(
+            ["-serial", f"unix:{serial_socket},server=on,wait=off"],
+        )
+    else:
+        cmd.extend(["-serial", "none"])
+    cmd.extend(
+        [
+            "-monitor",
+            "stdio",
+            "-display",
+            "none",
+            "-no-reboot",
+            "-no-shutdown",
+        ],
+    )
     return subprocess.Popen(
         cmd,
         stdin=subprocess.PIPE,
@@ -107,13 +117,58 @@ def send_shell_command(process, cmd_text):
     time.sleep(0.1)
 
 
+def run_agent_transport_probe(process, log_file, serial_socket):
+    probe = subprocess.Popen(
+        [
+            sys.executable,
+            "scripts/agent_transport_probe.py",
+            "--socket",
+            serial_socket,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        send_shell_command(process, "agent transport ping")
+        if not check_log_for("Agent transport: connected", log_file, timeout=6):
+            fail_with_log("Agent transport probe did not complete.", process, log_file)
+        try:
+            probe.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            fail_with_log("Host transport probe did not exit.", process, log_file)
+        if probe.returncode != 0:
+            print("--- Agent transport probe stderr ---")
+            print(probe.stderr.read())
+            print("------------------------------------")
+            fail_with_log("Host transport probe failed.", process, log_file)
+
+        send_shell_command(process, "agent transport ping")
+        if not check_log_for("agent: transport timeout", log_file, timeout=6):
+            fail_with_log("Transport timeout was not reported.", process, log_file)
+
+        send_shell_command(process, "version")
+        if not check_log_for("DavOS 0.5.0 (64bit)", log_file, timeout=6):
+            fail_with_log("Shell did not recover from transport timeout.", process, log_file)
+    finally:
+        if probe.poll() is None:
+            probe.terminate()
+            probe.wait(timeout=2)
+        if probe.stdout is not None:
+            probe.stdout.close()
+        if probe.stderr is not None:
+            probe.stderr.close()
+
+
 def run_functional_suite(iso_path, disk_img, log_file):
     if os.path.exists(log_file):
         os.remove(log_file)
 
-    process = start_qemu(iso_path, disk_img, log_file)
+    serial_socket = "qemu-agent.sock"
+    process = start_qemu(iso_path, disk_img, log_file, serial_socket)
     try:
         wait_for_boot(process, log_file)
+        run_agent_transport_probe(process, log_file, serial_socket)
 
         test_cases = [
             ("help", ["Commands:", "agent"]),
@@ -169,6 +224,8 @@ def run_functional_suite(iso_path, disk_img, log_file):
             print(f"Test Passed: '{cmd_text}' command executed successfully.")
     finally:
         stop_qemu(process)
+        if os.path.exists(serial_socket):
+            os.remove(serial_socket)
 
 
 def run_fault_probe(iso_path, disk_img, cmd_text, log_file, fault_marker="PF"):

--- a/serial/frame.go
+++ b/serial/frame.go
@@ -1,0 +1,204 @@
+package serial
+
+const (
+	FrameVersion byte = 1
+
+	MaxRequestPayload  = 2048
+	MaxResponsePayload = 1024
+	MaxPayload         = MaxRequestPayload
+
+	frameHeaderSize  = 6
+	frameTrailerSize = 2
+	MaxFrameSize     = frameHeaderSize + MaxPayload + frameTrailerSize
+)
+
+const (
+	frameMagicFirst  byte = 'D'
+	frameMagicSecond byte = 'V'
+)
+
+type FrameKind uint8
+
+const (
+	FrameRequest FrameKind = iota + 1
+	FrameResponse
+)
+
+type Result uint8
+
+const (
+	ResultOK Result = iota
+	ResultNeedMore
+	ResultInvalidPayload
+	ResultPortUnavailable
+	ResultWriteTimeout
+	ResultReadTimeout
+	ResultPartialFrame
+	ResultMalformedFrame
+	ResultOversizedFrame
+	ResultUnexpectedFrame
+)
+
+type Frame struct {
+	Kind    FrameKind
+	Payload [MaxPayload]byte
+	Length  int
+}
+
+type Decoder struct {
+	frame       Frame
+	state       uint8
+	checksum    uint16
+	receivedCRC uint16
+	payloadRead int
+}
+
+const (
+	decodeMagicFirst uint8 = iota
+	decodeMagicSecond
+	decodeVersion
+	decodeKind
+	decodeLengthHigh
+	decodeLengthLow
+	decodePayload
+	decodeChecksumHigh
+	decodeChecksumLow
+)
+
+func Encode(kind FrameKind, payload *[MaxPayload]byte, payloadLen int, output *[MaxFrameSize]byte) (int, Result) {
+	if output == nil || payloadLen < 0 || payload == nil && payloadLen != 0 {
+		return 0, ResultInvalidPayload
+	}
+	if !kind.valid() {
+		return 0, ResultMalformedFrame
+	}
+	if payloadLen > MaxPayload || payloadLen > kind.maxPayload() {
+		return 0, ResultOversizedFrame
+	}
+
+	output[0] = frameMagicFirst
+	output[1] = frameMagicSecond
+	output[2] = FrameVersion
+	output[3] = byte(kind)
+	output[4] = byte(payloadLen >> 8)
+	output[5] = byte(payloadLen)
+
+	checksum := uint16(0xFFFF)
+	for i := 2; i < frameHeaderSize; i++ {
+		checksum = updateChecksum(checksum, output[i])
+	}
+	for i := 0; i < payloadLen; i++ {
+		output[frameHeaderSize+i] = payload[i]
+		checksum = updateChecksum(checksum, payload[i])
+	}
+
+	checksumOffset := frameHeaderSize + payloadLen
+	output[checksumOffset] = byte(checksum >> 8)
+	output[checksumOffset+1] = byte(checksum)
+	return checksumOffset + frameTrailerSize, ResultOK
+}
+
+func (d *Decoder) Reset() {
+	d.frame.Kind = 0
+	d.frame.Length = 0
+	d.state = decodeMagicFirst
+	d.checksum = 0xFFFF
+	d.receivedCRC = 0
+	d.payloadRead = 0
+}
+
+func (d *Decoder) Push(value byte) Result {
+	switch d.state {
+	case decodeMagicFirst:
+		if value != frameMagicFirst {
+			d.Reset()
+			return ResultMalformedFrame
+		}
+		d.state = decodeMagicSecond
+	case decodeMagicSecond:
+		if value != frameMagicSecond {
+			d.Reset()
+			return ResultMalformedFrame
+		}
+		d.state = decodeVersion
+	case decodeVersion:
+		if value != FrameVersion {
+			d.Reset()
+			return ResultMalformedFrame
+		}
+		d.checksum = updateChecksum(d.checksum, value)
+		d.state = decodeKind
+	case decodeKind:
+		d.frame.Kind = FrameKind(value)
+		if !d.frame.Kind.valid() {
+			d.Reset()
+			return ResultMalformedFrame
+		}
+		d.checksum = updateChecksum(d.checksum, value)
+		d.state = decodeLengthHigh
+	case decodeLengthHigh:
+		d.frame.Length = int(value) << 8
+		d.checksum = updateChecksum(d.checksum, value)
+		d.state = decodeLengthLow
+	case decodeLengthLow:
+		d.frame.Length |= int(value)
+		d.checksum = updateChecksum(d.checksum, value)
+		if d.frame.Length > d.frame.Kind.maxPayload() {
+			d.Reset()
+			return ResultOversizedFrame
+		}
+		if d.frame.Length == 0 {
+			d.state = decodeChecksumHigh
+		} else {
+			d.state = decodePayload
+		}
+	case decodePayload:
+		d.frame.Payload[d.payloadRead] = value
+		d.payloadRead++
+		d.checksum = updateChecksum(d.checksum, value)
+		if d.payloadRead == d.frame.Length {
+			d.state = decodeChecksumHigh
+		}
+	case decodeChecksumHigh:
+		d.receivedCRC = uint16(value) << 8
+		d.state = decodeChecksumLow
+	case decodeChecksumLow:
+		d.receivedCRC |= uint16(value)
+		if d.receivedCRC != d.checksum {
+			d.Reset()
+			return ResultMalformedFrame
+		}
+		return ResultOK
+	default:
+		d.Reset()
+		return ResultMalformedFrame
+	}
+	return ResultNeedMore
+}
+
+func (d *Decoder) Frame() *Frame {
+	return &d.frame
+}
+
+func (kind FrameKind) valid() bool {
+	return kind == FrameRequest || kind == FrameResponse
+}
+
+func (kind FrameKind) maxPayload() int {
+	if kind == FrameResponse {
+		return MaxResponsePayload
+	}
+	return MaxRequestPayload
+}
+
+func updateChecksum(checksum uint16, value byte) uint16 {
+	checksum ^= uint16(value) << 8
+	for i := 0; i < 8; i++ {
+		if checksum&0x8000 != 0 {
+			checksum = checksum<<1 ^ 0x1021
+		} else {
+			checksum <<= 1
+		}
+	}
+	return checksum
+}

--- a/serial/frame_test.go
+++ b/serial/frame_test.go
@@ -1,0 +1,243 @@
+package serial
+
+import "testing"
+
+func TestChecksumMatchesCCITTFalseVector(t *testing.T) {
+	checksum := uint16(0xFFFF)
+	for i := 0; i < len("123456789"); i++ {
+		checksum = updateChecksum(checksum, "123456789"[i])
+	}
+	if checksum != 0x29B1 {
+		t.Fatalf("checksum = 0x%04X, expected 0x29B1", checksum)
+	}
+}
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		kind    FrameKind
+		payload string
+	}{
+		{name: "request", kind: FrameRequest, payload: "show me the files"},
+		{name: "response", kind: FrameResponse, payload: "list_files"},
+		{name: "empty response", kind: FrameResponse},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := payloadForTest(tt.payload)
+			var encoded [MaxFrameSize]byte
+			encodedLen, result := Encode(tt.kind, &payload, len(tt.payload), &encoded)
+			if result != ResultOK {
+				t.Fatalf("Encode() result = %d", result)
+			}
+
+			var decoder Decoder
+			decoder.Reset()
+			for i := 0; i < encodedLen; i++ {
+				result = decoder.Push(encoded[i])
+				if i < encodedLen-1 && result != ResultNeedMore {
+					t.Fatalf("Push() at %d = %d", i, result)
+				}
+			}
+			if result != ResultOK {
+				t.Fatalf("final Push() result = %d", result)
+			}
+			frame := decoder.Frame()
+			if frame.Kind != tt.kind || frame.Length != len(tt.payload) {
+				t.Fatalf("decoded frame = kind %d length %d", frame.Kind, frame.Length)
+			}
+			for i := 0; i < frame.Length; i++ {
+				if frame.Payload[i] != tt.payload[i] {
+					t.Fatalf("payload byte %d = %q", i, frame.Payload[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFramingRejectsInvalidInput(t *testing.T) {
+	var payload [MaxPayload]byte
+	var output [MaxFrameSize]byte
+
+	tests := []struct {
+		name       string
+		kind       FrameKind
+		payloadLen int
+		payload    *[MaxPayload]byte
+		output     *[MaxFrameSize]byte
+		want       Result
+	}{
+		{name: "negative length", kind: FrameRequest, payloadLen: -1, payload: &payload, output: &output, want: ResultInvalidPayload},
+		{name: "nil payload", kind: FrameRequest, payloadLen: 1, output: &output, want: ResultInvalidPayload},
+		{name: "nil output", kind: FrameRequest, payload: &payload, want: ResultInvalidPayload},
+		{name: "unknown kind", kind: FrameKind(99), payload: &payload, output: &output, want: ResultMalformedFrame},
+		{name: "request too large", kind: FrameRequest, payloadLen: MaxRequestPayload + 1, payload: &payload, output: &output, want: ResultOversizedFrame},
+		{name: "response too large", kind: FrameResponse, payloadLen: MaxResponsePayload + 1, payload: &payload, output: &output, want: ResultOversizedFrame},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, got := Encode(tt.kind, tt.payload, tt.payloadLen, tt.output); got != tt.want {
+				t.Fatalf("Encode() result = %d, expected %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecoderRejectsMalformedFrames(t *testing.T) {
+	valid, validLen := encodedForTest(t, FrameResponse, "pong")
+
+	tests := []struct {
+		name  string
+		frame [MaxFrameSize]byte
+		len   int
+		want  Result
+	}{
+		{name: "bad magic", frame: changedByte(valid, 0, 'X'), len: validLen, want: ResultMalformedFrame},
+		{name: "bad version", frame: changedByte(valid, 2, FrameVersion+1), len: validLen, want: ResultMalformedFrame},
+		{name: "bad kind", frame: changedByte(valid, 3, 99), len: validLen, want: ResultMalformedFrame},
+		{name: "bad checksum", frame: changedByte(valid, validLen-1, valid[validLen-1]^0xFF), len: validLen, want: ResultMalformedFrame},
+		{name: "partial", frame: valid, len: validLen - 1, want: ResultNeedMore},
+		{name: "oversized response", frame: oversizedResponseHeader(), len: frameHeaderSize, want: ResultOversizedFrame},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var decoder Decoder
+			decoder.Reset()
+			result := ResultNeedMore
+			for i := 0; i < tt.len; i++ {
+				result = decoder.Push(tt.frame[i])
+				if result != ResultNeedMore {
+					break
+				}
+			}
+			if result != tt.want {
+				t.Fatalf("decoder result = %d, expected %d", result, tt.want)
+			}
+		})
+	}
+}
+
+func TestExchangeSendsRequestAndReceivesResponse(t *testing.T) {
+	reply, replyLen := encodedForTest(t, FrameResponse, "pong")
+	ConfigureResponseForTesting(&reply, replyLen)
+	t.Cleanup(ResetForTesting)
+
+	request := payloadForTest("ping")
+	var response [MaxPayload]byte
+	responseLen, result := Exchange(&request, 4, &response)
+	if result != ResultOK || responseLen != 4 || string(response[:responseLen]) != "pong" {
+		t.Fatalf("Exchange() = length %d result %d payload %q", responseLen, result, response[:responseLen])
+	}
+
+	var decoder Decoder
+	decoder.Reset()
+	for i := 0; i < testOutputLen; i++ {
+		result = decoder.Push(testOutput[i])
+	}
+	frame := decoder.Frame()
+	if result != ResultOK || frame.Kind != FrameRequest || frame.Length != 4 || string(frame.Payload[:frame.Length]) != "ping" {
+		t.Fatalf("outbound frame = kind %d length %d result %d", frame.Kind, frame.Length, result)
+	}
+}
+
+func TestExchangeFailsSafely(t *testing.T) {
+	valid, validLen := encodedForTest(t, FrameResponse, "pong")
+	request := payloadForTest("ping")
+	var response [MaxPayload]byte
+
+	tests := []struct {
+		name      string
+		configure func()
+		want      Result
+	}{
+		{name: "port unavailable", configure: ResetForTesting, want: ResultPortUnavailable},
+		{name: "write timeout", configure: func() {
+			ResetForTesting()
+			testPortAvailable = true
+		}, want: ResultWriteTimeout},
+		{name: "read timeout", configure: func() {
+			ConfigureResponseForTesting(nil, 0)
+		}, want: ResultReadTimeout},
+		{name: "partial frame", configure: func() {
+			ConfigureResponseForTesting(&valid, validLen-1)
+		}, want: ResultPartialFrame},
+		{name: "bad checksum", configure: func() {
+			malformed := changedByte(valid, validLen-1, valid[validLen-1]^0xFF)
+			ConfigureResponseForTesting(&malformed, validLen)
+		}, want: ResultMalformedFrame},
+		{name: "oversized response", configure: func() {
+			oversized := oversizedResponseHeader()
+			ConfigureResponseForTesting(&oversized, frameHeaderSize)
+		}, want: ResultOversizedFrame},
+		{name: "request returned as response", configure: func() {
+			wrongKind, wrongKindLen := encodedForTest(t, FrameRequest, "pong")
+			ConfigureResponseForTesting(&wrongKind, wrongKindLen)
+		}, want: ResultUnexpectedFrame},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.configure()
+			if _, result := Exchange(&request, 4, &response); result != tt.want {
+				t.Fatalf("Exchange() result = %d, expected %d", result, tt.want)
+			}
+		})
+	}
+	ResetForTesting()
+}
+
+func TestExchangeRecoversAfterMalformedResponse(t *testing.T) {
+	valid, validLen := encodedForTest(t, FrameResponse, "pong")
+	malformed := changedByte(valid, validLen-1, valid[validLen-1]^0xFF)
+	request := payloadForTest("ping")
+	var response [MaxPayload]byte
+
+	ConfigureResponseForTesting(&malformed, validLen)
+	if _, result := Exchange(&request, 4, &response); result != ResultMalformedFrame {
+		t.Fatalf("malformed Exchange() result = %d", result)
+	}
+	ConfigureResponseForTesting(&valid, validLen)
+	if responseLen, result := Exchange(&request, 4, &response); result != ResultOK || responseLen != 4 {
+		t.Fatalf("recovery Exchange() = length %d result %d", responseLen, result)
+	}
+	ResetForTesting()
+}
+
+func payloadForTest(value string) [MaxPayload]byte {
+	var payload [MaxPayload]byte
+	for i := 0; i < len(value); i++ {
+		payload[i] = value[i]
+	}
+	return payload
+}
+
+func encodedForTest(t *testing.T, kind FrameKind, value string) ([MaxFrameSize]byte, int) {
+	t.Helper()
+	payload := payloadForTest(value)
+	var encoded [MaxFrameSize]byte
+	encodedLen, result := Encode(kind, &payload, len(value), &encoded)
+	if result != ResultOK {
+		t.Fatalf("Encode() result = %d", result)
+	}
+	return encoded, encodedLen
+}
+
+func changedByte(frame [MaxFrameSize]byte, offset int, value byte) [MaxFrameSize]byte {
+	frame[offset] = value
+	return frame
+}
+
+func oversizedResponseHeader() [MaxFrameSize]byte {
+	var frame [MaxFrameSize]byte
+	frame[0] = frameMagicFirst
+	frame[1] = frameMagicSecond
+	frame[2] = FrameVersion
+	frame[3] = byte(FrameResponse)
+	length := MaxResponsePayload + 1
+	frame[4] = byte(length >> 8)
+	frame[5] = byte(length)
+	return frame
+}

--- a/serial/io_gccgo.go
+++ b/serial/io_gccgo.go
@@ -1,0 +1,44 @@
+//go:build gccgo
+
+package serial
+
+const (
+	com1Base       uint16 = 0x3F8
+	lineStatusPort        = com1Base + 5
+	dataReady      byte   = 1
+	transmitReady  byte   = 1 << 5
+)
+
+func inb(port uint16) byte
+func outb(port uint16, value byte)
+
+func initPort() bool {
+	outb(com1Base+1, 0x00)
+	outb(com1Base+3, 0x80)
+	outb(com1Base, 0x03)
+	outb(com1Base+1, 0x00)
+	outb(com1Base+3, 0x03)
+	outb(com1Base+2, 0xC7)
+	outb(com1Base+4, 0x1E)
+	outb(com1Base, 0xAE)
+	if inb(com1Base) != 0xAE {
+		return false
+	}
+	outb(com1Base+4, 0x0F)
+	return true
+}
+
+func tryWriteByte(value byte) bool {
+	if inb(lineStatusPort)&transmitReady == 0 {
+		return false
+	}
+	outb(com1Base, value)
+	return true
+}
+
+func tryReadByte() (byte, bool) {
+	if inb(lineStatusPort)&dataReady == 0 {
+		return 0, false
+	}
+	return inb(com1Base), true
+}

--- a/serial/io_testing.go
+++ b/serial/io_testing.go
@@ -1,0 +1,68 @@
+//go:build testing
+
+package serial
+
+var (
+	testPortAvailable  bool
+	testWriteAvailable bool
+	testReply          [MaxFrameSize]byte
+	testReplyLen       int
+	testReplyQueued    bool
+	testInput          [MaxFrameSize]byte
+	testInputLen       int
+	testInputOffset    int
+	testOutput         [MaxFrameSize]byte
+	testOutputLen      int
+)
+
+func ResetForTesting() {
+	testPortAvailable = false
+	testWriteAvailable = false
+	testReplyLen = 0
+	testReplyQueued = false
+	testInputLen = 0
+	testInputOffset = 0
+	testOutputLen = 0
+}
+
+func ConfigureResponseForTesting(frame *[MaxFrameSize]byte, frameLen int) {
+	ResetForTesting()
+	testPortAvailable = true
+	testWriteAvailable = true
+	if frame == nil || frameLen < 0 || frameLen > MaxFrameSize {
+		return
+	}
+	for i := 0; i < frameLen; i++ {
+		testReply[i] = frame[i]
+	}
+	testReplyLen = frameLen
+}
+
+func initPort() bool {
+	return testPortAvailable
+}
+
+func tryWriteByte(value byte) bool {
+	if !testWriteAvailable || testOutputLen >= MaxFrameSize {
+		return false
+	}
+	testOutput[testOutputLen] = value
+	testOutputLen++
+	if !testReplyQueued && testReplyLen > 0 {
+		for i := 0; i < testReplyLen; i++ {
+			testInput[i] = testReply[i]
+		}
+		testInputLen = testReplyLen
+		testReplyQueued = true
+	}
+	return true
+}
+
+func tryReadByte() (byte, bool) {
+	if testInputOffset >= testInputLen {
+		return 0, false
+	}
+	value := testInput[testInputOffset]
+	testInputOffset++
+	return value, true
+}

--- a/serial/stubs.go
+++ b/serial/stubs.go
@@ -1,0 +1,7 @@
+//go:build !gccgo && !testing
+
+package serial
+
+func initPort() bool               { return false }
+func tryWriteByte(value byte) bool { return false }
+func tryReadByte() (byte, bool)    { return 0, false }

--- a/serial/transport.go
+++ b/serial/transport.go
@@ -1,0 +1,72 @@
+package serial
+
+const maxPortPolls = 1000000
+
+var (
+	encodedRequest  [MaxFrameSize]byte
+	responseDecoder Decoder
+)
+
+// Exchange sends one request and waits for one response. It is intentionally
+// single-flight so the freestanding guest can use fixed-size storage only.
+func Exchange(request *[MaxPayload]byte, requestLen int, response *[MaxPayload]byte) (int, Result) {
+	if response == nil {
+		return 0, ResultInvalidPayload
+	}
+	frameLen, result := Encode(FrameRequest, request, requestLen, &encodedRequest)
+	if result != ResultOK {
+		return 0, result
+	}
+	if !initPort() {
+		return 0, ResultPortUnavailable
+	}
+
+	drainInput()
+	written := 0
+	for polls := 0; written < frameLen && polls < maxPortPolls; polls++ {
+		if tryWriteByte(encodedRequest[written]) {
+			written++
+		}
+	}
+	if written != frameLen {
+		return 0, ResultWriteTimeout
+	}
+
+	responseDecoder.Reset()
+	bytesRead := 0
+	for polls := 0; polls < maxPortPolls; polls++ {
+		value, ok := tryReadByte()
+		if !ok {
+			continue
+		}
+		bytesRead++
+		result = responseDecoder.Push(value)
+		if result == ResultNeedMore {
+			continue
+		}
+		if result != ResultOK {
+			return 0, result
+		}
+
+		frame := responseDecoder.Frame()
+		if frame.Kind != FrameResponse {
+			return 0, ResultUnexpectedFrame
+		}
+		for i := 0; i < frame.Length; i++ {
+			response[i] = frame.Payload[i]
+		}
+		return frame.Length, ResultOK
+	}
+	if bytesRead != 0 {
+		return 0, ResultPartialFrame
+	}
+	return 0, ResultReadTimeout
+}
+
+func drainInput() {
+	for i := 0; i < MaxFrameSize*2; i++ {
+		if _, ok := tryReadByte(); !ok {
+			return
+		}
+	}
+}

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dmarro89/go-dav-os/fs"
 	"github.com/dmarro89/go-dav-os/fs/fat16"
 	"github.com/dmarro89/go-dav-os/mem"
+	"github.com/dmarro89/go-dav-os/serial"
 	"github.com/dmarro89/go-dav-os/terminal"
 )
 
@@ -22,16 +23,18 @@ const (
 )
 
 var (
-	lineBuf         [maxLine]byte
-	lineLen         int
-	getTicks        func() uint64
-	getSyscallTicks func() uint64
-	runProgram      func(name *[16]byte, nameLen int) (pid int, ok bool)
-	switchLayoutFn  func(string) bool
-	currentLayout   = "it"
-	tmpName         [16]byte
-	tmpData         [4096]byte
-	diskBuf         [512]byte
+	lineBuf           [maxLine]byte
+	lineLen           int
+	getTicks          func() uint64
+	getSyscallTicks   func() uint64
+	runProgram        func(name *[16]byte, nameLen int) (pid int, ok bool)
+	switchLayoutFn    func(string) bool
+	currentLayout     = "it"
+	tmpName           [16]byte
+	tmpData           [4096]byte
+	diskBuf           [512]byte
+	transportRequest  [serial.MaxPayload]byte
+	transportResponse [serial.MaxPayload]byte
 
 	// History ring buffer
 	// historyBuf stores the content of the commands
@@ -811,7 +814,7 @@ func execute() {
 	if matchLiteral(cmdStart, cmdEnd, "agent") {
 		a1s, a1e, ok := nextArg(cmdEnd, end)
 		if !ok {
-			terminal.Print("Usage: agent <show|read|stat|delete|mode|context|help> [arg]\n")
+			terminal.Print("Usage: agent <show|read|stat|delete|mode|transport|context|help> [arg]\n")
 			return
 		}
 
@@ -870,6 +873,19 @@ func execute() {
 				return
 			}
 			runAgentNoTarget(agent.ActionSetMode, agent.IntentSetMode, agent.RiskSafe, start, end)
+			return
+		} else if matchLiteral(a1s, a1e, "transport") {
+			a2s, a2e, ok := nextArg(a1e, end)
+			if !ok {
+				terminal.Print("Usage: agent transport ping\n")
+				return
+			}
+			_, _, extra := nextArg(a2e, end)
+			if extra || !matchLiteral(a2s, a2e, "ping") {
+				terminal.Print("Usage: agent transport ping\n")
+				return
+			}
+			runAgentTransportProbe()
 			return
 		} else if matchLiteral(a1s, a1e, "context") {
 			printAgentContext(&agentContext)
@@ -943,6 +959,39 @@ func runAgentAction(kind agent.ActionKind, intent agent.IntentKind, risk agent.R
 	terminal.PutRune('\n')
 }
 
+func runAgentTransportProbe() {
+	transportRequest[0] = 'p'
+	transportRequest[1] = 'i'
+	transportRequest[2] = 'n'
+	transportRequest[3] = 'g'
+	responseLen, result := serial.Exchange(&transportRequest, 4, &transportResponse)
+	if result != serial.ResultOK {
+		printAgentTransportError(result)
+		terminal.PutRune('\n')
+		return
+	}
+	if responseLen != 4 || transportResponse[0] != 'p' || transportResponse[1] != 'o' || transportResponse[2] != 'n' || transportResponse[3] != 'g' {
+		terminal.Print("agent: transport invalid response\n")
+		return
+	}
+	terminal.Print("Agent transport: connected\n")
+}
+
+func printAgentTransportError(result serial.Result) {
+	switch result {
+	case serial.ResultPortUnavailable:
+		terminal.Print("agent: transport unavailable")
+	case serial.ResultWriteTimeout, serial.ResultReadTimeout:
+		terminal.Print("agent: transport timeout")
+	case serial.ResultPartialFrame:
+		terminal.Print("agent: transport partial response")
+	case serial.ResultOversizedFrame:
+		terminal.Print("agent: transport response too large")
+	default:
+		terminal.Print("agent: transport malformed response")
+	}
+}
+
 func printAgentMessage(message agent.MessageKind) {
 	switch message {
 	case agent.MessagePlannerFailed:
@@ -1000,6 +1049,7 @@ func printAgentMessage(message agent.MessageKind) {
 		terminal.Print("  agent stat <name>   - Show file metadata through the agent\n")
 		terminal.Print("  agent delete <name> - Delete a file after confirmation\n")
 		terminal.Print("  agent mode [mode]   - Show or switch agent mode\n")
+		terminal.Print("  agent transport ping - Probe the guest-host transport\n")
 		terminal.Print("  agent context       - Show current agent context\n")
 		terminal.Print("  agent help          - Show agent commands")
 	case agent.MessageHistoryListed:

--- a/shell/shell_test.go
+++ b/shell/shell_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/dmarro89/go-dav-os/agent"
 	"github.com/dmarro89/go-dav-os/fs"
+	"github.com/dmarro89/go-dav-os/serial"
 	"github.com/dmarro89/go-dav-os/terminal"
 )
 
@@ -465,7 +466,7 @@ func TestExecuteAgentCommand(t *testing.T) {
 		{
 			name:  "missing command",
 			input: "agent",
-			want:  "Usage: agent <show|read|stat|delete|mode|context|help> [arg]\n",
+			want:  "Usage: agent <show|read|stat|delete|mode|transport|context|help> [arg]\n",
 		},
 		{
 			name:  "missing show argument",
@@ -538,15 +539,26 @@ func TestExecuteAgentCommand(t *testing.T) {
 			want:  "Current planner: deterministic\n",
 		},
 		{
+			name:  "transport unavailable",
+			input: "agent transport ping",
+			want:  "agent: transport unavailable\n",
+		},
+		{
+			name:  "transport rejects extra arguments",
+			input: "agent transport ping extra",
+			want:  "Usage: agent transport ping\n",
+		},
+		{
 			name:  "help",
 			input: "agent help",
-			want:  "Agent commands:\n  agent show files    - Show files managed by the agent\n  agent show history  - Show command history stored by the agent\n  agent show version  - Show OS version through the agent\n  agent show ticks    - Show PIT ticks through the agent\n  agent show memorymap - Show memory map through the agent\n  agent read <name>   - Read a file through the agent\n  agent stat <name>   - Show file metadata through the agent\n  agent delete <name> - Delete a file after confirmation\n  agent mode [mode]   - Show or switch agent mode\n  agent context       - Show current agent context\n  agent help          - Show agent commands\n",
+			want:  "Agent commands:\n  agent show files    - Show files managed by the agent\n  agent show history  - Show command history stored by the agent\n  agent show version  - Show OS version through the agent\n  agent show ticks    - Show PIT ticks through the agent\n  agent show memorymap - Show memory map through the agent\n  agent read <name>   - Read a file through the agent\n  agent stat <name>   - Show file metadata through the agent\n  agent delete <name> - Delete a file after confirmation\n  agent mode [mode]   - Show or switch agent mode\n  agent transport ping - Probe the guest-host transport\n  agent context       - Show current agent context\n  agent help          - Show agent commands\n",
 		},
 	}
 
 	terminal.Init()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			serial.ResetForTesting()
 			terminal.ResetOutputForTesting()
 			agentContext = agent.Context{}
 			setLineBuf(tt.input)
@@ -557,6 +569,45 @@ func TestExecuteAgentCommand(t *testing.T) {
 				t.Fatalf("execute(%q) output = %q, expected %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestExecuteAgentTransportRoundTripAndRecovery(t *testing.T) {
+	var payload [serial.MaxPayload]byte
+	payload[0] = 'p'
+	payload[1] = 'o'
+	payload[2] = 'n'
+	payload[3] = 'g'
+	var response [serial.MaxFrameSize]byte
+	responseLen, result := serial.Encode(serial.FrameResponse, &payload, 4, &response)
+	if result != serial.ResultOK {
+		t.Fatalf("Encode() result = %d", result)
+	}
+
+	serial.ConfigureResponseForTesting(&response, responseLen)
+	t.Cleanup(serial.ResetForTesting)
+	terminal.Init()
+	terminal.ResetOutputForTesting()
+	setLineBuf("agent transport ping")
+	execute()
+	if got := terminal.OutputForTesting(); got != "Agent transport: connected\n" {
+		t.Fatalf("successful transport output = %q", got)
+	}
+
+	response[responseLen-1] ^= 0xFF
+	serial.ConfigureResponseForTesting(&response, responseLen)
+	terminal.ResetOutputForTesting()
+	setLineBuf("agent transport ping")
+	execute()
+	if got := terminal.OutputForTesting(); got != "agent: transport malformed response\n" {
+		t.Fatalf("malformed transport output = %q", got)
+	}
+
+	terminal.ResetOutputForTesting()
+	setLineBuf("version")
+	execute()
+	if got := terminal.OutputForTesting(); got != "DavOS 0.5.0 (64bit)\n" {
+		t.Fatalf("shell output after transport failure = %q", got)
 	}
 }
 


### PR DESCRIPTION
## What

- add a bounded `DV/1` request/response frame with CRC-16, 2048-byte request and 1024-byte response limits
- add a polled COM1 guest transport and a one-shot host probe over a QEMU Unix serial socket
- add `agent transport ping`, safe transport errors, focused unit coverage and QEMU round-trip coverage
- document the wire format, endpoint, limits and trust boundary

## Why

This establishes the minimal guest-host byte channel required before the host bridge and provider work can begin. It keeps JSON, provider calls, credentials and networking outside the kernel.

Closes #184

## How to test

- `make test`
- `go vet -tags testing -unsafeptr=false ./...`
- `golangci-lint run --timeout=5m`
- build the ISO, then run `python3 scripts/test_boot.py --functional`
- manually run `make run-agent-transport`, start `python3 scripts/agent_transport_probe.py`, and execute `agent transport ping` in DavOS

## Pre-flight

- [x] `gofmt -l .` prints nothing
- [x] `go vet -tags testing -unsafeptr=false ./...` is clean
- [x] `make test` passes
- [x] `python3 scripts/test_boot.py` passes
- [x] PR is a single concern (no drive-by cleanups)

ISO and QEMU validation passed in this PR's CI.

AI was used for assistance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `agent transport ping` to verify communication with the QEMU agent.
  * Added bounded, checksummed serial transport with clear timeout and protocol error reporting.
  * Added QEMU support for connecting through a Unix serial socket.
  * Added a command-line probe for validating the agent transport connection.

* **Documentation**
  * Documented transport framing, limits, validation, and failure handling.
  * Added the transport guide to documentation navigation.

* **Testing**
  * Expanded coverage for exchanges, malformed responses, timeouts, recovery, and end-to-end probing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->