### PR TITLE
Add host Agent bridge service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,6 +336,7 @@ vet:
 test:
 	mkdir -p $(BUILD_DIR)/.gocache
 	GOCACHE=$(CURDIR)/$(BUILD_DIR)/.gocache go test -tags testing $(TEST_PKGS)
+	python3 -m unittest discover -s scripts -p 'test_*.py'
 
 # -----------------------
 # User hello

--- a/docs/v0.6.0/agent_transport.md
+++ b/docs/v0.6.0/agent_transport.md
@@ -37,6 +37,9 @@ The guest sends a framed `ping`; the host validates it and returns a framed
 `pong`. A successful round trip prints `Agent transport: connected`. The probe
 contains no provider or networking logic and exists only to verify the channel.
 
+For the host planning service built on this channel, see
+[`host_bridge.md`](./host_bridge.md).
+
 ## Wire frame
 
 Every integer uses network byte order (big-endian).

--- a/docs/v0.6.0/host_bridge.md
+++ b/docs/v0.6.0/host_bridge.md
@@ -1,0 +1,56 @@
+# v0.6.0 Host Agent Bridge
+
+Issue #185 turns the transport probe into a small host service. The service
+reads one framed JSON request at a time, delegates planning to a host provider
+and writes one framed JSON response. The guest still validates every typed plan
+before execution.
+
+## Run with the fake provider
+
+Start QEMU with the Agent serial socket:
+
+```sh
+make run-agent-transport
+```
+
+Then start the bridge in another terminal:
+
+```sh
+python3 scripts/agent_bridge.py --socket /tmp/davos-agent.sock
+```
+
+The deterministic fake provider is the default. It needs no network access or
+credentials and uses the mappings from the
+[v0.5.0 fake bridge](../v0.5.0/fake_llm_bridge.md).
+
+## OpenAI-compatible provider
+
+Provider configuration exists only in the host process environment:
+
+```sh
+export DAVOS_AGENT_PROVIDER=openai
+export DAVOS_AGENT_API_KEY='<provider API key>'
+export DAVOS_AGENT_MODEL='<model name>'
+export DAVOS_AGENT_BASE_URL='https://provider.example/v1'
+python3 scripts/agent_bridge.py --socket /tmp/davos-agent.sock
+```
+
+The base URL must be the provider's API root; the bridge appends
+`/chat/completions`. The API key is used only in the host HTTP authorization
+header. It is never logged, included in a transport frame or sent to the guest.
+
+## Boundaries
+
+- `agent_bridge_transport.py` owns the QEMU Unix serial connection.
+- `agent_bridge_protocol.py` owns `DV/1` framing and JSON encoding limits.
+- `agent_bridge_provider.py` owns fake and OpenAI-compatible provider calls.
+- `agent_bridge.py` processes requests sequentially and coordinates errors.
+
+Requests remain limited to 2048 bytes and responses to 1024 bytes. Provider
+and protocol failures become bounded JSON error objects. Fatal transport errors
+are emitted as the same bounded JSON shape on stderr and terminate the service.
+The service does not expose a public network endpoint and never puts provider
+configuration or credentials in the kernel.
+
+The constrained prompt and strict semantic response validation are implemented
+separately by issue #186.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,3 +19,4 @@ nav:
   - v0.5.0 LLM Bridge Protocol: v0.5.0/llm_bridge_protocol.md
   - v0.5.0 Fake LLM Bridge: v0.5.0/fake_llm_bridge.md
   - v0.6.0 QEMU Agent Transport: v0.6.0/agent_transport.md
+  - v0.6.0 Host Agent Bridge: v0.6.0/host_bridge.md

--- a/scripts/agent_bridge.py
+++ b/scripts/agent_bridge.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Serve Agent planning requests over the QEMU serial transport."""
+
+import argparse
+import json
+import os
+import sys
+import time
+
+from agent_bridge_protocol import (
+    ProtocolError,
+    decode_agent_request,
+    encode_agent_response,
+    error_response,
+)
+from agent_bridge_provider import ProviderError, provider_from_environment
+from agent_bridge_transport import connect
+
+
+def response_for_payload(payload, provider):
+    try:
+        request = decode_agent_request(payload)
+        response = provider.plan(request)
+        return encode_agent_response(response)
+    except (ProtocolError, ProviderError) as error:
+        safe_error = error_response(error.code, str(error))
+        return encode_agent_response(safe_error)
+
+
+def serve(transport, provider, timeout, once=False):
+    while True:
+        try:
+            payload = transport.receive(time.monotonic() + timeout)
+        except ProtocolError as error:
+            if not error.recoverable:
+                raise
+            safe_error = error_response(error.code, str(error))
+            transport.send(
+                encode_agent_response(safe_error), time.monotonic() + timeout
+            )
+            continue
+        response = response_for_payload(payload, provider)
+        transport.send(response, time.monotonic() + timeout)
+        if once:
+            return
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--socket", default="/tmp/davos-agent.sock")
+    parser.add_argument("--timeout", type=float, default=10.0)
+    parser.add_argument("--once", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        provider = provider_from_environment(os.environ)
+        connect_deadline = time.monotonic() + args.timeout
+        with connect(args.socket, connect_deadline) as transport:
+            serve(transport, provider, args.timeout, args.once)
+    except (ProtocolError, ProviderError, OSError) as error:
+        code = getattr(error, "code", "transport_error")
+        json.dump(error_response(code, str(error)), sys.stderr, separators=(",", ":"))
+        sys.stderr.write("\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agent_bridge_protocol.py
+++ b/scripts/agent_bridge_protocol.py
@@ -1,0 +1,91 @@
+"""Bounded DV/1 framing and Agent JSON protocol helpers."""
+
+import binascii
+import json
+
+
+MAGIC = b"DV"
+VERSION = 1
+REQUEST = 1
+RESPONSE = 2
+HEADER_SIZE = 6
+MAX_REQUEST_PAYLOAD = 2048
+MAX_RESPONSE_PAYLOAD = 1024
+MAX_ERROR_MESSAGE = 96
+
+
+class ProtocolError(Exception):
+    def __init__(self, message, code="protocol_error", recoverable=False):
+        super().__init__(message)
+        self.code = code
+        self.recoverable = recoverable
+
+
+def checksum(data):
+    return binascii.crc_hqx(data, 0xFFFF)
+
+
+def request_payload_length(header):
+    if len(header) != HEADER_SIZE:
+        raise ProtocolError("partial frame")
+    if header[:2] != MAGIC or header[2] != VERSION or header[3] != REQUEST:
+        raise ProtocolError("malformed request header")
+    payload_len = int.from_bytes(header[4:6], "big")
+    if payload_len > MAX_REQUEST_PAYLOAD:
+        raise ProtocolError("request payload is too large")
+    return payload_len
+
+
+def decode_request_body(header, body):
+    payload_len = request_payload_length(header)
+    if len(body) != payload_len + 2:
+        raise ProtocolError("partial frame")
+    payload = body[:-2]
+    received_checksum = int.from_bytes(body[-2:], "big")
+    if received_checksum != checksum(header[2:] + payload):
+        raise ProtocolError("request checksum mismatch", recoverable=True)
+    return payload
+
+
+def encode_response_frame(payload):
+    if len(payload) > MAX_RESPONSE_PAYLOAD:
+        raise ProtocolError("response payload is too large")
+    header = MAGIC + bytes((VERSION, RESPONSE)) + len(payload).to_bytes(2, "big")
+    return header + payload + checksum(header[2:] + payload).to_bytes(2, "big")
+
+
+def decode_agent_request(payload):
+    try:
+        request = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as error:
+        raise ProtocolError("request must be valid UTF-8 JSON", "invalid_request") from error
+    if not isinstance(request, dict):
+        raise ProtocolError("request must be a JSON object", "invalid_request")
+    return request
+
+
+def encode_agent_response(response):
+    if not isinstance(response, dict):
+        raise ProtocolError("provider response must be a JSON object", "invalid_response")
+    try:
+        payload = json.dumps(response, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    except (TypeError, ValueError) as error:
+        raise ProtocolError("provider response must be valid JSON", "invalid_response") from error
+    if len(payload) > MAX_RESPONSE_PAYLOAD:
+        raise ProtocolError("provider response is too large", "invalid_response")
+    return payload
+
+
+def error_response(code, message):
+    response = {
+        "error": {
+            "code": str(code)[:32],
+            "message": str(message)[:MAX_ERROR_MESSAGE],
+        }
+    }
+    while (
+        len(json.dumps(response, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+        > MAX_RESPONSE_PAYLOAD
+    ):
+        response["error"]["message"] = response["error"]["message"][:-1]
+    return response

--- a/scripts/agent_bridge_provider.py
+++ b/scripts/agent_bridge_provider.py
@@ -1,0 +1,111 @@
+"""Host-only providers for the Agent bridge service."""
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+
+import fake_llm_bridge
+
+
+MAX_PROVIDER_BODY = 65536
+
+
+class ProviderError(Exception):
+    def __init__(self, message, code="provider_error"):
+        super().__init__(message)
+        self.code = code
+
+
+class Provider:
+    def plan(self, request):
+        raise NotImplementedError
+
+
+class FakeProvider(Provider):
+    def plan(self, request):
+        return fake_llm_bridge.plan_for_request(request)
+
+
+class OpenAICompatibleProvider(Provider):
+    def __init__(self, api_key, model, base_url, timeout=10.0):
+        try:
+            scheme = urllib.parse.urlsplit(base_url).scheme.lower()
+        except ValueError as error:
+            raise ProviderError(
+                "provider endpoint must use http or https", "provider_config"
+            ) from error
+        if scheme not in ("http", "https"):
+            raise ProviderError(
+                "provider endpoint must use http or https", "provider_config"
+            )
+        self.api_key = api_key
+        self.model = model
+        self.endpoint = base_url.rstrip("/") + "/chat/completions"
+        self.timeout = timeout
+
+    def plan(self, request):
+        body = json.dumps(
+            {
+                "model": self.model,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+                            "Return only one JSON object matching the Agent bridge "
+                            "response protocol."
+                        ),
+                    },
+                    {"role": "user", "content": json.dumps(request, separators=(",", ":"))},
+                ],
+            }
+        ).encode("utf-8")
+        try:
+            provider_request = urllib.request.Request(
+                self.endpoint,
+                data=body,
+                headers={
+                    "Authorization": "Bearer " + self.api_key,
+                    "Content-Type": "application/json",
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(provider_request, timeout=self.timeout) as response:
+                raw_response = response.read(MAX_PROVIDER_BODY + 1)
+        except (OSError, TimeoutError, ValueError, urllib.error.URLError) as error:
+            raise ProviderError("provider request failed") from error
+        if len(raw_response) > MAX_PROVIDER_BODY:
+            raise ProviderError("provider response is too large")
+
+        try:
+            envelope = json.loads(raw_response.decode("utf-8"))
+            content = envelope["choices"][0]["message"]["content"]
+            plan = json.loads(content)
+        except (
+            KeyError,
+            IndexError,
+            TypeError,
+            UnicodeDecodeError,
+            json.JSONDecodeError,
+            RecursionError,
+        ) as error:
+            raise ProviderError("provider returned an invalid response") from error
+        if not isinstance(plan, dict):
+            raise ProviderError("provider returned an invalid response")
+        return plan
+
+
+def provider_from_environment(environment):
+    provider_name = (environment.get("DAVOS_AGENT_PROVIDER", "") or "").strip().lower()
+    provider_name = provider_name or "fake"
+    if provider_name == "fake":
+        return FakeProvider()
+    if provider_name != "openai":
+        raise ProviderError("unsupported provider", "provider_config")
+
+    api_key = environment.get("DAVOS_AGENT_API_KEY", "")
+    model = environment.get("DAVOS_AGENT_MODEL", "")
+    base_url = environment.get("DAVOS_AGENT_BASE_URL", "")
+    if not api_key or not model or not base_url:
+        raise ProviderError("openai provider configuration is incomplete", "provider_config")
+    return OpenAICompatibleProvider(api_key, model, base_url)

--- a/scripts/agent_bridge_transport.py
+++ b/scripts/agent_bridge_transport.py
@@ -1,0 +1,85 @@
+"""Unix stream adapter for the QEMU Agent serial transport."""
+
+import socket
+import time
+
+from agent_bridge_protocol import (
+    HEADER_SIZE,
+    ProtocolError,
+    decode_request_body,
+    encode_response_frame,
+    request_payload_length,
+)
+
+
+def remaining_timeout(deadline):
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise ProtocolError("transport timed out", "transport_timeout")
+    return remaining
+
+
+def read_exact(stream, size, deadline):
+    data = bytearray()
+    while len(data) < size:
+        stream.settimeout(remaining_timeout(deadline))
+        try:
+            chunk = stream.recv(size - len(data))
+        except socket.timeout as error:
+            raise ProtocolError("transport timed out", "transport_timeout") from error
+        except OSError as error:
+            raise ProtocolError("transport read failed", "transport_error") from error
+        if not chunk:
+            raise ProtocolError("partial frame")
+        data.extend(chunk)
+    return bytes(data)
+
+
+class SerialTransport:
+    def __init__(self, stream):
+        self.stream = stream
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self.close()
+
+    def close(self):
+        self.stream.close()
+
+    def receive(self, deadline):
+        header = read_exact(self.stream, HEADER_SIZE, deadline)
+        payload_len = request_payload_length(header)
+        body = read_exact(self.stream, payload_len + 2, deadline)
+        return decode_request_body(header, body)
+
+    def send(self, payload, deadline):
+        self.stream.settimeout(remaining_timeout(deadline))
+        try:
+            self.stream.sendall(encode_response_frame(payload))
+        except socket.timeout as error:
+            raise ProtocolError("transport timed out", "transport_timeout") from error
+        except OSError as error:
+            raise ProtocolError("transport write failed", "transport_error") from error
+
+
+def connect(path, deadline):
+    while True:
+        stream = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            stream.settimeout(remaining_timeout(deadline))
+            stream.connect(path)
+            return SerialTransport(stream)
+        except ProtocolError:
+            stream.close()
+            raise
+        except socket.timeout as error:
+            stream.close()
+            raise ProtocolError("transport timed out", "transport_timeout") from error
+        except (FileNotFoundError, ConnectionRefusedError):
+            stream.close()
+            time.sleep(min(0.05, remaining_timeout(deadline)))
+        except OSError as error:
+            stream.close()
+            raise ProtocolError("transport connection failed", "transport_error") from error

--- a/scripts/agent_transport_probe.py
+++ b/scripts/agent_transport_probe.py
@@ -2,87 +2,10 @@
 """Serve one framed transport probe over the QEMU Agent serial socket."""
 
 import argparse
-import binascii
-import socket
 import time
 
-
-MAGIC = b"DV"
-VERSION = 1
-REQUEST = 1
-RESPONSE = 2
-HEADER_SIZE = 6
-MAX_REQUEST_PAYLOAD = 2048
-MAX_RESPONSE_PAYLOAD = 1024
-
-
-class ProtocolError(Exception):
-    pass
-
-
-def checksum(data):
-    return binascii.crc_hqx(data, 0xFFFF)
-
-
-def remaining_timeout(deadline):
-    remaining = deadline - time.monotonic()
-    if remaining <= 0:
-        raise ProtocolError("probe timed out")
-    return remaining
-
-
-def read_exact(stream, size, deadline):
-    data = bytearray()
-    while len(data) < size:
-        stream.settimeout(remaining_timeout(deadline))
-        try:
-            chunk = stream.recv(size - len(data))
-        except socket.timeout as error:
-            raise ProtocolError("probe timed out") from error
-        if not chunk:
-            raise ProtocolError("partial frame")
-        data.extend(chunk)
-    return bytes(data)
-
-
-def read_request(stream, deadline):
-    header = read_exact(stream, HEADER_SIZE, deadline)
-    if header[:2] != MAGIC or header[2] != VERSION or header[3] != REQUEST:
-        raise ProtocolError("malformed request header")
-    payload_len = int.from_bytes(header[4:6], "big")
-    if payload_len > MAX_REQUEST_PAYLOAD:
-        raise ProtocolError("request payload is too large")
-    body = read_exact(stream, payload_len + 2, deadline)
-    payload = body[:-2]
-    received_checksum = int.from_bytes(body[-2:], "big")
-    if received_checksum != checksum(header[2:] + payload):
-        raise ProtocolError("request checksum mismatch")
-    return payload
-
-
-def encode_response(payload):
-    if len(payload) > MAX_RESPONSE_PAYLOAD:
-        raise ProtocolError("response payload is too large")
-    header = MAGIC + bytes((VERSION, RESPONSE)) + len(payload).to_bytes(2, "big")
-    return header + payload + checksum(header[2:] + payload).to_bytes(2, "big")
-
-
-def connect(path, deadline):
-    while True:
-        stream = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        try:
-            stream.settimeout(remaining_timeout(deadline))
-            stream.connect(path)
-            return stream
-        except ProtocolError:
-            stream.close()
-            raise
-        except socket.timeout as error:
-            stream.close()
-            raise ProtocolError("probe timed out") from error
-        except (FileNotFoundError, ConnectionRefusedError):
-            stream.close()
-            time.sleep(min(0.05, remaining_timeout(deadline)))
+from agent_bridge_protocol import ProtocolError
+from agent_bridge_transport import connect
 
 
 def main():
@@ -92,15 +15,11 @@ def main():
     args = parser.parse_args()
 
     deadline = time.monotonic() + args.timeout
-    with connect(args.socket, deadline) as stream:
-        request = read_request(stream, deadline)
+    with connect(args.socket, deadline) as transport:
+        request = transport.receive(deadline)
         if request != b"ping":
             raise ProtocolError("unexpected probe payload")
-        stream.settimeout(remaining_timeout(deadline))
-        try:
-            stream.sendall(encode_response(b"pong"))
-        except socket.timeout as error:
-            raise ProtocolError("probe timed out") from error
+        transport.send(b"pong", deadline)
 
 
 if __name__ == "__main__":

--- a/scripts/test_agent_bridge.py
+++ b/scripts/test_agent_bridge.py
@@ -1,0 +1,342 @@
+import io
+import json
+import sys
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPTS = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPTS))
+
+import agent_bridge
+import agent_bridge_protocol
+import agent_bridge_provider
+import agent_bridge_transport
+
+
+DEFAULT_REQUEST = {
+    "input": "show me the files",
+    "context": {},
+    "allowedActions": ["list_files", "read_file"],
+}
+
+
+class MemoryTransport:
+    def __init__(self, payload):
+        self.payload = payload
+        self.response = None
+        self.receive_deadline = None
+        self.send_deadline = None
+
+    def receive(self, deadline):
+        self.receive_deadline = deadline
+        return self.payload
+
+    def send(self, payload, deadline):
+        self.response = payload
+        self.send_deadline = deadline
+
+
+class FakeStream:
+    def __init__(self, incoming):
+        self.incoming = bytearray(incoming)
+        self.sent = bytearray()
+        self.timeout = None
+        self.closed = False
+
+    def settimeout(self, timeout):
+        self.timeout = timeout
+
+    def recv(self, size):
+        chunk = self.incoming[:size]
+        del self.incoming[:size]
+        return bytes(chunk)
+
+    def sendall(self, data):
+        self.sent.extend(data)
+
+    def close(self):
+        self.closed = True
+
+
+class FakeHTTPResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def read(self, _size):
+        return self.payload
+
+
+def request_frame(payload):
+    header = (
+        agent_bridge_protocol.MAGIC
+        + bytes((agent_bridge_protocol.VERSION, agent_bridge_protocol.REQUEST))
+        + len(payload).to_bytes(2, "big")
+    )
+    crc = agent_bridge_protocol.checksum(header[2:] + payload).to_bytes(2, "big")
+    return header + payload + crc
+
+
+class AgentBridgeTest(unittest.TestCase):
+    def test_fake_provider_serves_one_structured_request(self):
+        transport = MemoryTransport(json.dumps(DEFAULT_REQUEST).encode("utf-8"))
+
+        agent_bridge.serve(transport, agent_bridge_provider.FakeProvider(), 1.0, once=True)
+
+        response = json.loads(transport.response)
+        self.assertEqual(response["intent"], "list_files")
+        self.assertEqual(response["action"], "list_files")
+        self.assertNotIn("error", response)
+
+    def test_provider_failure_returns_bounded_structured_error(self):
+        class FailingProvider:
+            def plan(self, _request):
+                raise agent_bridge_provider.ProviderError("provider request failed")
+
+        payload = agent_bridge.response_for_payload(
+            json.dumps(DEFAULT_REQUEST).encode("utf-8"), FailingProvider()
+        )
+
+        response = json.loads(payload)
+        self.assertEqual(response["error"]["code"], "provider_error")
+        self.assertEqual(response["error"]["message"], "provider request failed")
+        self.assertLessEqual(len(payload), agent_bridge_protocol.MAX_RESPONSE_PAYLOAD)
+
+    def test_non_ascii_provider_failure_is_bounded(self):
+        class FailingProvider:
+            def plan(self, _request):
+                raise agent_bridge_provider.ProviderError("🔥" * 1000)
+
+        payload = agent_bridge.response_for_payload(
+            json.dumps(DEFAULT_REQUEST).encode("utf-8"), FailingProvider()
+        )
+
+        self.assertEqual(json.loads(payload)["error"]["code"], "provider_error")
+        self.assertLessEqual(len(payload), agent_bridge_protocol.MAX_RESPONSE_PAYLOAD)
+
+    def test_invalid_request_returns_structured_error(self):
+        payload = agent_bridge.response_for_payload(
+            b"not-json", agent_bridge_provider.FakeProvider()
+        )
+
+        response = json.loads(payload)
+        self.assertEqual(response["error"]["code"], "invalid_request")
+        self.assertLessEqual(len(payload), agent_bridge_protocol.MAX_RESPONSE_PAYLOAD)
+
+    def test_recursive_json_request_is_invalid(self):
+        with mock.patch.object(
+            agent_bridge_protocol.json, "loads", side_effect=RecursionError
+        ):
+            with self.assertRaises(agent_bridge_protocol.ProtocolError) as raised:
+                agent_bridge_protocol.decode_agent_request(b"{}")
+
+        self.assertEqual(raised.exception.code, "invalid_request")
+        self.assertIsInstance(raised.exception.__cause__, RecursionError)
+
+    def test_provider_processing_gets_a_separate_send_window(self):
+        transport = MemoryTransport(json.dumps(DEFAULT_REQUEST).encode("utf-8"))
+
+        with mock.patch.object(agent_bridge.time, "monotonic", side_effect=(10.0, 20.0)):
+            agent_bridge.serve(
+                transport, agent_bridge_provider.FakeProvider(), 1.0, once=True
+            )
+
+        self.assertEqual(transport.receive_deadline, 11.0)
+        self.assertEqual(transport.send_deadline, 21.0)
+
+    def test_serial_transport_reads_and_writes_dv1_frames(self):
+        payload = json.dumps(DEFAULT_REQUEST).encode("utf-8")
+        stream = FakeStream(request_frame(payload))
+        transport = agent_bridge_transport.SerialTransport(stream)
+        deadline = time.monotonic() + 1.0
+
+        self.assertEqual(transport.receive(deadline), payload)
+        transport.send(b"{}", deadline)
+
+        self.assertEqual(
+            bytes(stream.sent), agent_bridge_protocol.encode_response_frame(b"{}")
+        )
+
+    def test_transport_failure_is_structured_and_bounded(self):
+        payload = json.dumps(DEFAULT_REQUEST).encode("utf-8")
+        invalid_frame = bytearray(request_frame(payload))
+        invalid_frame[-1] ^= 1
+        stream = FakeStream(bytes(invalid_frame) + request_frame(payload))
+        transport = agent_bridge_transport.SerialTransport(stream)
+
+        agent_bridge.serve(
+            transport, agent_bridge_provider.FakeProvider(), 1.0, once=True
+        )
+
+        first_payload_len = int.from_bytes(stream.sent[4:6], "big")
+        first_payload = bytes(stream.sent[6 : 6 + first_payload_len])
+        second_frame_offset = 6 + first_payload_len + 2
+        second_payload_len = int.from_bytes(
+            stream.sent[second_frame_offset + 4 : second_frame_offset + 6], "big"
+        )
+        second_payload = bytes(
+            stream.sent[
+                second_frame_offset + 6 : second_frame_offset + 6 + second_payload_len
+            ]
+        )
+
+        self.assertEqual(json.loads(first_payload)["error"]["code"], "protocol_error")
+        self.assertLessEqual(
+            len(first_payload), agent_bridge_protocol.MAX_RESPONSE_PAYLOAD
+        )
+        self.assertEqual(json.loads(second_payload)["action"], "list_files")
+
+    def test_partial_frame_terminates_service(self):
+        payload = json.dumps(DEFAULT_REQUEST).encode("utf-8")
+        stream = FakeStream(request_frame(payload)[:-1])
+        transport = agent_bridge_transport.SerialTransport(stream)
+
+        with self.assertRaises(agent_bridge_protocol.ProtocolError):
+            agent_bridge.serve(
+                transport, agent_bridge_provider.FakeProvider(), 1.0, once=True
+            )
+
+        self.assertEqual(stream.sent, b"")
+
+    def test_send_failure_terminates_service(self):
+        class FailingSendTransport(MemoryTransport):
+            def send(self, _payload, _deadline):
+                raise agent_bridge_protocol.ProtocolError(
+                    "transport write failed", "transport_error"
+                )
+
+        transport = FailingSendTransport(json.dumps(DEFAULT_REQUEST).encode("utf-8"))
+
+        with self.assertRaises(agent_bridge_protocol.ProtocolError) as raised:
+            agent_bridge.serve(
+                transport, agent_bridge_provider.FakeProvider(), 1.0, once=True
+            )
+
+        self.assertEqual(raised.exception.code, "transport_error")
+
+    def test_provider_selection_is_host_environment_only(self):
+        self.assertIsInstance(
+            agent_bridge_provider.provider_from_environment({}),
+            agent_bridge_provider.FakeProvider,
+        )
+        self.assertIsInstance(
+            agent_bridge_provider.provider_from_environment(
+                {"DAVOS_AGENT_PROVIDER": "   "}
+            ),
+            agent_bridge_provider.FakeProvider,
+        )
+        with self.assertRaises(agent_bridge_provider.ProviderError) as raised:
+            agent_bridge_provider.provider_from_environment(
+                {"DAVOS_AGENT_PROVIDER": "unsupported"}
+            )
+        self.assertEqual(raised.exception.code, "provider_config")
+        provider = agent_bridge_provider.provider_from_environment(
+            {
+                "DAVOS_AGENT_PROVIDER": "openai",
+                "DAVOS_AGENT_API_KEY": "secret",
+                "DAVOS_AGENT_MODEL": "test-model",
+                "DAVOS_AGENT_BASE_URL": "https://provider.example/v1",
+            }
+        )
+        self.assertIsInstance(provider, agent_bridge_provider.OpenAICompatibleProvider)
+        self.assertEqual(provider.model, "test-model")
+        self.assertEqual(provider.endpoint, "https://provider.example/v1/chat/completions")
+
+    def test_openai_compatible_provider_rejects_non_http_endpoint(self):
+        with self.assertRaises(agent_bridge_provider.ProviderError) as raised:
+            agent_bridge_provider.OpenAICompatibleProvider(
+                "secret", "test-model", "file:///tmp/provider"
+            )
+
+        self.assertEqual(raised.exception.code, "provider_config")
+
+    def test_openai_compatible_provider_returns_json_plan_without_network(self):
+        provider = agent_bridge_provider.OpenAICompatibleProvider(
+            "secret", "test-model", "https://provider.example/v1"
+        )
+        envelope = {
+            "choices": [
+                {
+                    "message": {
+                        "content": json.dumps(
+                            {
+                                "intent": "list_files",
+                                "action": "list_files",
+                                "args": [],
+                                "risk": "safe",
+                            }
+                        )
+                    }
+                }
+            ]
+        }
+
+        def fake_urlopen(request, timeout):
+            self.assertEqual(request.get_header("Authorization"), "Bearer secret")
+            self.assertEqual(request.full_url, provider.endpoint)
+            self.assertEqual(timeout, 10.0)
+            return FakeHTTPResponse(json.dumps(envelope).encode("utf-8"))
+
+        with mock.patch.object(agent_bridge_provider.urllib.request, "urlopen", fake_urlopen):
+            response = provider.plan(DEFAULT_REQUEST)
+
+        self.assertEqual(response["action"], "list_files")
+        self.assertNotIn("secret", json.dumps(response))
+
+    def test_recursive_provider_response_is_structured_and_bounded(self):
+        class RecursiveProvider(agent_bridge_provider.OpenAICompatibleProvider):
+            def plan(self, request):
+                with mock.patch.object(
+                    agent_bridge_provider.json, "loads", side_effect=RecursionError
+                ):
+                    return super().plan(request)
+
+        provider = RecursiveProvider(
+            "secret", "test-model", "https://provider.example/v1"
+        )
+        with mock.patch.object(
+            agent_bridge_provider.urllib.request,
+            "urlopen",
+            return_value=FakeHTTPResponse(b"{}"),
+        ):
+            payload = agent_bridge.response_for_payload(
+                json.dumps(DEFAULT_REQUEST).encode("utf-8"), provider
+            )
+
+        self.assertEqual(json.loads(payload)["error"]["code"], "provider_error")
+        self.assertLessEqual(len(payload), agent_bridge_protocol.MAX_RESPONSE_PAYLOAD)
+
+    def test_main_reports_socket_failures_as_transport_errors(self):
+        stderr = io.StringIO()
+        with (
+            mock.patch.object(agent_bridge, "connect", side_effect=OSError("socket failed")),
+            mock.patch.object(agent_bridge.sys, "argv", ["agent_bridge.py"]),
+            mock.patch.object(agent_bridge.sys, "stderr", stderr),
+        ):
+            status = agent_bridge.main()
+
+        self.assertEqual(status, 1)
+        self.assertEqual(json.loads(stderr.getvalue())["error"]["code"], "transport_error")
+
+    def test_incomplete_provider_configuration_does_not_echo_secrets(self):
+        environment = {
+            "DAVOS_AGENT_PROVIDER": "openai",
+            "DAVOS_AGENT_API_KEY": "do-not-log",
+        }
+
+        with self.assertRaises(agent_bridge_provider.ProviderError) as raised:
+            agent_bridge_provider.provider_from_environment(environment)
+
+        self.assertNotIn("do-not-log", str(raised.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

- add a sequential host Agent bridge over the existing `DV/1` serial transport
- separate bounded protocol, Unix transport and provider responsibilities
- support deterministic fake and host-configured OpenAI-compatible providers
- add offline unit tests and host bridge documentation

## Why

This turns the v0.6.0 transport probe into the small host planning service required before the guest BridgeClient can use a real provider. Provider credentials and configuration remain outside the guest.

Closes #185

## How to test

- `make test`
- `make vet`
- `python3 scripts/test_boot.py`

## Pre-flight

- [x] Python bridge tests pass without network or API credentials
- [x] `git diff --check` is clean
- [x] `gofmt -l .` prints nothing
- [x] `go vet -tags testing -unsafeptr=false ./...` is clean
- [x] `make test` passes
- [x] `python3 scripts/test_boot.py` passes
- [x] PR is a single concern (no drive-by cleanups)

All toolchain, ISO and QEMU gates passed in [Build #334](https://github.com/dmarro89/go-dav-os/actions/runs/31167744145).

AI was used for assistance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a host-side agent bridge for QEMU planning requests.
  - Supports fake and OpenAI-compatible providers with configurable credentials, models, endpoints, and timeouts.
  - Added bounded request/response handling with structured errors and secure secret handling.
  - Improved Unix socket connectivity with timeout and connection-error reporting.

- **Documentation**
  - Added setup, configuration, security, troubleshooting, and host-bridge planning guidance.

- **Tests**
  - Expanded coverage for bridge behavior, transport, providers, errors, timeouts, and secret redaction.
  - The test command now also runs Python unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->