### PR TITLE
Require commit sign-off in CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,6 +24,7 @@ Closes #
 - [ ] `go vet -tags testing -unsafeptr=false ./...` is clean
 - [ ] `make test` passes
 - [ ] `python3 scripts/test_boot.py` passes
+- [ ] Every commit includes a `Signed-off-by` trailer
 - [ ] PR is a single concern (no drive-by cleanups)
 
 <!-- If AI was used substantially in this PR, leave one line below: "AI was used for assistance." -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,7 @@ Closes #
 - [ ] `go vet -tags testing -unsafeptr=false ./...` is clean
 - [ ] `make test` passes
 - [ ] `python3 scripts/test_boot.py` passes
-- [ ] Every commit includes a `Signed-off-by` trailer
+- [ ] Every commit includes a valid `Signed-off-by: Human Name <email>` trailer
 - [ ] PR is a single concern (no drive-by cleanups)
 
 <!-- If AI was used substantially in this PR, leave one line below: "AI was used for assistance." -->

--- a/.github/workflows/build-and-run.yml
+++ b/.github/workflows/build-and-run.yml
@@ -25,15 +25,32 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          signoff_pattern='^Signed-off-by: [^<>[:space:]]([^<>]*[^<>[:space:]])? <[^<>[:space:]@]+@[^<>[:space:]@]+>$'
+          if ! grep --extended-regexp --quiet "$signoff_pattern" <<< 'Signed-off-by: Human Name <human@example.com>'; then
+            echo "::error::The sign-off pattern rejected a valid trailer."
+            exit 1
+          fi
+          if grep --extended-regexp --quiet "$signoff_pattern" <<< 'Signed-off-by: Human Name <a@@b>'; then
+            echo "::error::The sign-off pattern accepted an invalid trailer."
+            exit 1
+          fi
+
+          if ! commits="$(git rev-list "$BASE_SHA..$HEAD_SHA")"; then
+            echo "::error::Unable to enumerate the pull-request commit range."
+            exit 1
+          fi
+
           missing=0
-          while IFS= read -r commit; do
-            if ! git show -s --format=%B "$commit" \
-              | git interpret-trailers --parse \
-              | grep --extended-regexp --quiet '^Signed-off-by: [^<>]+ <[^<>[:space:]]+@[^<>[:space:]]+>$'; then
-              echo "::error::Commit $commit is missing a valid Signed-off-by trailer."
-              missing=1
-            fi
-          done < <(git rev-list "$BASE_SHA..$HEAD_SHA")
+          if [ -n "$commits" ]; then
+            while IFS= read -r commit; do
+              if ! git show -s --format=%B "$commit" \
+                | git interpret-trailers --parse \
+                | grep --extended-regexp --quiet "$signoff_pattern"; then
+                echo "::error::Commit $commit is missing a valid Signed-off-by trailer."
+                missing=1
+              fi
+            done <<< "$commits"
+          fi
 
           if [ "$missing" -ne 0 ]; then
             echo "Sign each commit with 'git commit -s' and push the updated history."

--- a/.github/workflows/build-and-run.yml
+++ b/.github/workflows/build-and-run.yml
@@ -16,6 +16,29 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check commit sign-offs
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          missing=0
+          while IFS= read -r commit; do
+            if ! git show -s --format=%B "$commit" \
+              | git interpret-trailers --parse \
+              | grep --extended-regexp --quiet '^Signed-off-by: [^<>]+ <[^<>[:space:]]+@[^<>[:space:]]+>$'; then
+              echo "::error::Commit $commit is missing a valid Signed-off-by trailer."
+              missing=1
+            fi
+          done < <(git rev-list "$BASE_SHA..$HEAD_SHA")
+
+          if [ "$missing" -ne 0 ]; then
+            echo "Sign each commit with 'git commit -s' and push the updated history."
+            exit 1
+          fi
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,8 @@ go-dav-os is a 64-bit freestanding hobby kernel written in Go (`gccgo`, x86_64 l
 4. **Don't touch `boot/boot.s`, the Multiboot2 header layout, or paging/IDT setup unless the issue is explicitly about them.** Those are load-bearing.
 5. **No standard library imports in kernel code.** This is a freestanding build (`gccgo`, no stdlib). Stick to packages already imported in the file you're editing.
 6. **Comments explain *why*, not *what*.** Identifier names already say what; only comment when the reasoning would otherwise be lost.
-7. **Disclose AI authorship in the PR body** when the change was substantially agent-written. One line is enough: `AI was used for assistance.` Do not advertise the engine name or describe verification — keep it short.
+7. **Sign every commit.** Each commit must contain a well-formed `Signed-off-by` trailer identifying the responsible human contributor. Use `git commit -s`; never put an AI tool in this trailer.
+8. **Disclose AI authorship in the PR body** when the change was substantially agent-written. One line is enough: `AI was used for assistance.` Do not advertise the engine name or describe verification — keep it short.
 
 ## Recommended workflow
 
@@ -28,11 +29,13 @@ go-dav-os is a 64-bit freestanding hobby kernel written in Go (`gccgo`, x86_64 l
 2. Open the relevant file before changing it. Match the existing style of that file (indentation, comment density, error-handling shape).
 3. Keep diffs small. Aim for under 100 added lines on a first contribution.
 4. Run the full gate stack locally. If a gate fails, fix it locally — do not push and let CI fail.
-5. Follow the [PR template](.github/pull_request_template.md). Three lines (what / why / how to test) is the minimum, not a suggestion.
+5. Commit with a human sign-off using `git commit -s`.
+6. Follow the [PR template](.github/pull_request_template.md). Three lines (what / why / how to test) is the minimum, not a suggestion.
 
 ## Things that get auto-rejected
 
 - PRs that fail `gofmt` or `go vet`.
+- PRs containing a commit without a valid `Signed-off-by` trailer.
 - PRs that bundle unrelated cleanups with the actual fix.
 - PRs that import new third-party Go modules into kernel code.
 - PRs that add `TODO`/`FIXME` comments without an issue link.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,9 @@ The workflow is the classic one:
 1. Fork the repo
 2. Create a branch (`feat/...`, `fix/...`, `docs/...` — nothing strict here)
 3. Do the change
-4. Make sure it still builds and runs (same commands as in the README)
-5. Open the PR
+4. Sign every commit with `git commit -s`
+5. Make sure it still builds and runs (same commands as in the README)
+6. Open the PR
 
 In the PR description, please write 2–3 lines:
 - what you changed
@@ -55,6 +56,18 @@ In the PR description, please write 2–3 lines:
 - how I can test it (what command to run / what output to expect)
 
 That’s enough.
+
+## Commit sign-off
+
+Every commit in a PR must include a well-formed `Signed-off-by` trailer identifying the human who accepts responsibility for the contribution under the [Developer Certificate of Origin](https://developercertificate.org/). Add it automatically with:
+
+```bash
+git commit -s -m "Describe the change"
+```
+
+For the most recent commit, add a missing sign-off with `git commit --amend -s`. For older commits, use an interactive rebase and amend each affected commit. Rewriting commits requires pushing the updated branch with `--force-with-lease`.
+
+The sign-off is a commit-message trailer, not a cryptographic GitHub “Verified” signature. CI checks every commit in a PR and rejects the PR when any sign-off is missing or malformed.
 
 ## A couple of guidelines (to keep things simple)
 - Prefer **small PRs** (one thing at a time)

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -10,6 +10,7 @@ If a PR can't tick the relevant items, it is either re-worked or closed.
 - [ ] `go vet -tags testing -unsafeptr=false ./...` reports no issues
 - [ ] `make test` passes locally
 - [ ] `python3 scripts/test_boot.py` passes (QEMU integration suite)
+- [ ] Every commit has a valid `Signed-off-by` trailer
 - [ ] CI on the PR is green
 
 ## Scope and shape


### PR DESCRIPTION
## What

Require every commit in a pull request to contain a well-formed human `Signed-off-by: Name <email>` trailer. The existing required `lint` job now checks the complete PR commit range before running the Go gates.

Document `git commit -s`, amendment/rebase recovery, and the distinction between sign-off trailers and cryptographic GitHub “Verified” signatures in the contributor, agent, review and PR-template guidance.

## Why

Permanent human accountability is the first concrete outcome of the discussion in #191. Keeping the validation inside the existing `lint` gate means an unsigned commit makes that gate fail and prevents the PR from satisfying the existing merge checks.

The separate AI attribution policy remains scoped to #194; this PR does not define or prematurely enforce `AI-Assisted-by`.

## How to test

- Inspect every commit in this PR with `git log --format='%H%n%(trailers:key=Signed-off-by)'`.
- Run the `Check commit sign-offs` step with `BASE_SHA` set to `main` and `HEAD_SHA` set to this branch; expect success.
- Remove a `Signed-off-by` trailer from a test commit and rerun the same step; expect exit status 1 and a GitHub error annotation for that commit.
- Let the normal `Build` workflow run; expect `lint` and `build-run` to pass.

## Pre-flight

- [x] `git diff --check` is clean
- [x] Every commit includes a `Signed-off-by` trailer
- [x] PR is a single concern (no drive-by cleanups)
- [x] GitHub Actions is green

AI was used for assistance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pull request validation to ensure every commit includes a valid `Signed-off-by` trailer.
* **Documentation**
  * Updated contribution and review guidance with commit sign-off requirements, correction steps, and rebasing instructions.
  * Added guidance for disclosing substantial AI authorship in pull requests.
  * Updated pull request templates and checklists to include commit sign-off verification.
  * Documented the required workflow for signing commits and resolving validation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->